### PR TITLE
CI: Move windows CI to its own CI

### DIFF
--- a/.github/workflows/CI-win.yaml
+++ b/.github/workflows/CI-win.yaml
@@ -12,30 +12,7 @@ on:
       - 'main'
 
 jobs:
-#  windows-ci:
-#    name: CI Windows
-#    runs-on: "windows-latest"
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: conda-incubator/setup-miniconda@v2
-#        with:
-#          activate-environment: anaconda-client-env
-#          environment-file: environment_dev.yaml
-#          python-version: 3.9
-#          auto-activate-base: false
-#
-#      - name: Lint
-#        shell: pwsh
-#        run: |
-#          invoke lint
-#          invoke black --checkonly
-#          invoke isort --checkonly
-#
-#      - name: Run tests
-#        shell: pwsh
-#        run: pytest -s
   build:
-
     strategy:
       matrix:
         include:
@@ -50,6 +27,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          # windows has a problem where sometimes if conda installs a version of a package
+          # but pip needs a higher version of that package (because of dependencies)
+          # an OSError can happen because of access issues.
+          # If that happens in the future, you can move that conda package to pip,
+          # Or pin it to a higher version
           python-version: 3.9
           activate-environment: boa
           environment-file: environment_dev.yaml

--- a/.github/workflows/CI-win.yaml
+++ b/.github/workflows/CI-win.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: ci-win
 
 on:
   push:
@@ -12,17 +12,43 @@ on:
       - 'main'
 
 jobs:
+#  windows-ci:
+#    name: CI Windows
+#    runs-on: "windows-latest"
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: conda-incubator/setup-miniconda@v2
+#        with:
+#          activate-environment: anaconda-client-env
+#          environment-file: environment_dev.yaml
+#          python-version: 3.9
+#          auto-activate-base: false
+#
+#      - name: Lint
+#        shell: pwsh
+#        run: |
+#          invoke lint
+#          invoke black --checkonly
+#          invoke isort --checkonly
+#
+#      - name: Run tests
+#        shell: pwsh
+#        run: pytest -s
   windows-ci:
-    name: CI Windows
-    runs-on: "windows-latest"
+    name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["windows-latest"]
+        python-version: ["3.9"]
     steps:
-      - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: anaconda-client-env
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          activate-environment: boa
           environment-file: environment_dev.yaml
-          python-version: 3.9
-          auto-activate-base: false
 
       - name: Lint
         shell: pwsh

--- a/.github/workflows/CI-win.yaml
+++ b/.github/workflows/CI-win.yaml
@@ -1,0 +1,36 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'main'
+
+  pull_request:
+    branches:
+      - 'develop'
+      - 'main'
+
+jobs:
+  windows-ci:
+    name: CI Windows
+    runs-on: "windows-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: anaconda-client-env
+          environment-file: example-environment.yml
+          python-version: 3.9
+          auto-activate-base: false
+
+      - name: Lint
+        shell: pwsh
+        run: |
+          invoke lint
+          invoke black --checkonly
+          invoke isort --checkonly
+
+      - name: Run tests
+        shell: pwsh
+        run: pytest -s

--- a/.github/workflows/CI-win.yaml
+++ b/.github/workflows/CI-win.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: anaconda-client-env
-          environment-file: environment_dev.yml
+          environment-file: environment_dev.yaml
           python-version: 3.9
           auto-activate-base: false
 

--- a/.github/workflows/CI-win.yaml
+++ b/.github/workflows/CI-win.yaml
@@ -43,6 +43,7 @@ jobs:
         os: ["windows-latest"]
         python-version: ["3.9"]
     steps:
+      - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/CI-win.yaml
+++ b/.github/workflows/CI-win.yaml
@@ -34,22 +34,25 @@ jobs:
 #      - name: Run tests
 #        shell: pwsh
 #        run: pytest -s
-  windows-ci:
-    name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+  build:
+
     strategy:
-      fail-fast: false
       matrix:
-        os: ["windows-latest"]
-        python-version: ["3.9"]
+        include:
+          - os: windows-latest
+            label: win-64
+            prefix: C:\Miniconda3\envs\boa
+
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
           activate-environment: boa
           environment-file: environment_dev.yaml
-          auto-activate-base: false
 
       - name: Lint
         shell: pwsh

--- a/.github/workflows/CI-win.yaml
+++ b/.github/workflows/CI-win.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
-          activate-environment: anaconda-client-env
+          activate-environment: boa
           environment-file: environment_dev.yaml
           auto-activate-base: false
 

--- a/.github/workflows/CI-win.yaml
+++ b/.github/workflows/CI-win.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: anaconda-client-env
-          environment-file: example-environment.yml
+          environment-file: environment_dev.yml
           python-version: 3.9
           auto-activate-base: false
 

--- a/.github/workflows/CI-win.yaml
+++ b/.github/workflows/CI-win.yaml
@@ -45,10 +45,10 @@ jobs:
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          activate-environment: boa
+          activate-environment: anaconda-client-env
           environment-file: environment_dev.yaml
+          auto-activate-base: false
 
       - name: Lint
         shell: pwsh

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,10 +28,6 @@ jobs:
             label: osx-64
             prefix: /Users/runner/miniconda3/envs/boa
 
-          - os: windows-latest
-            label: win-64
-            prefix: C:\Miniconda3\envs\boa
-
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -7,7 +7,6 @@ dependencies:
 - python=3.9
 - numpy
 - pandas
-- sphinx
 - xarray
 - dask
 - netCDF4
@@ -19,6 +18,7 @@ dependencies:
 - flake8
 - pip
 - pip:
+  - sphinx
   - torch
   - torchaudio
   - torchvision


### PR DESCRIPTION
We think that the windows CI caching env is messed up, so we are mvoing the windows CI to its own, non cached CI for now