### PR TITLE
Develop

### DIFF
--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -1,10 +1,11 @@
 import importlib.util
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import click
 
 from boa.controller import Controller
+from boa.wrapper_utils import cd_and_cd_back
 
 
 @click.command()
@@ -31,22 +32,34 @@ from boa.controller import Controller
 @click.option(
     "-at",
     "--append_timestamp",
-    is_flag=True, show_default=True, default=True, help="append timestamp to experiment directory"
+    is_flag=True,
+    show_default=True,
+    default=True,
+    help="Whether to append a timestamp to the end of the experiment directory to ensure uniqueness",
 )
-def main(config_path, wrapper_path, wrapper_name, append_timestamp):
-    module_name = "user_wrapper"
-    spec = importlib.util.spec_from_file_location(module_name, wrapper_path)
+@click.option(
+    "-d",
+    "--working_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Path to working dir to to cd to. "
+    "Can be necessary for certain languages and projects that need to be in a certain directory for imports.",
+)
+def main(config_path, wrapper_path, wrapper_name, append_timestamp, working_dir):
+    if working_dir:
+        sys.path.append(str(working_dir))
+    with cd_and_cd_back(working_dir):
+        module_name = "user_wrapper"
+        spec = importlib.util.spec_from_file_location(module_name, wrapper_path)
 
-    user_wrapper = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = user_wrapper
-    spec.loader.exec_module(user_wrapper)
+        user_wrapper = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = user_wrapper
+        spec.loader.exec_module(user_wrapper)
 
-    wrapper_cls = getattr(user_wrapper, wrapper_name)
-    print(user_wrapper)
-    print(wrapper_cls)
+        wrapper_cls = getattr(user_wrapper, wrapper_name)
 
-    controller = Controller(config_path=config_path, wrapper=wrapper_cls)
-    controller.run(append_timestamp=append_timestamp)
+        controller = Controller(config_path=config_path, wrapper=wrapper_cls)
+        controller.run(append_timestamp=append_timestamp)
 
 
 if __name__ == "__main__":

--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+import tempfile
 from pathlib import Path
 
 import click
@@ -30,6 +31,14 @@ from boa.wrapper_utils import cd_and_cd_back
     help="Name of wrapper class in boa wrapper class file",
 )
 @click.option(
+    "-d",
+    "--working_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Path to working dir to to cd to. "
+    "Can be necessary for certain languages and projects that need to be in a certain directory for imports.",
+)
+@click.option(
     "-at",
     "--append_timestamp",
     is_flag=True,
@@ -38,14 +47,36 @@ from boa.wrapper_utils import cd_and_cd_back
     help="Whether to append a timestamp to the end of the experiment directory to ensure uniqueness",
 )
 @click.option(
-    "-d",
-    "--working_dir",
+    "-o",
+    "--experiment_dir",
     type=click.Path(file_okay=False, path_type=Path),
     default=None,
-    help="Path to working dir to to cd to. "
-    "Can be necessary for certain languages and projects that need to be in a certain directory for imports.",
+    help="Modify/add to the config file the passed in experiment_dir for use downstream."
+    " This requires your Wrapper to have the ability to take experiment_dir as an argument"
+    " to ``load_config``. The default ``load_config`` does support this."
+    " --experiment_dir and --temp_dir can't both be used.",
 )
-def main(config_path, wrapper_path, wrapper_name, append_timestamp, working_dir):
+@click.option(
+    "-td",
+    "--temporary_dir",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Modify/add to the config file a temporary directory as the experiment_dir that will get deleted after running"
+    " (useful for testing)."
+    " This requires your Wrapper to have the ability to take experiment_dir as an argument"
+    " to ``load_config``. The default ``load_config`` does support this."
+    " --experiment_dir and --temp_dir can't both be used.",
+)
+def main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir, temporary_dir):
+    if temporary_dir:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            experiment_dir = Path(temp_dir) / "temp"
+            return _main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir)
+    return _main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir)
+
+
+def _main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir):
     if working_dir:
         sys.path.append(str(working_dir))
     with cd_and_cd_back(working_dir):
@@ -59,7 +90,8 @@ def main(config_path, wrapper_path, wrapper_name, append_timestamp, working_dir)
         wrapper_cls = getattr(user_wrapper, wrapper_name)
 
         controller = Controller(config_path=config_path, wrapper=wrapper_cls)
-        controller.run(append_timestamp=append_timestamp)
+        scheduler = controller.run(append_timestamp=append_timestamp, experiment_dir=experiment_dir)
+        return scheduler
 
 
 if __name__ == "__main__":

--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -1,0 +1,53 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import click
+
+from boa.controller import Controller
+
+
+@click.command()
+@click.option(
+    "-c",
+    "--config_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to configuration YAML file.",
+)
+@click.option(
+    "-w",
+    "--wrapper_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=Path(__file__).resolve().parent / "opt_config.yaml",
+    help="Path to file with boa wrapper class",
+)
+@click.option(
+    "-wn",
+    "--wrapper_name",
+    type=str,
+    default="Wrapper",
+    help="Name of wrapper class in boa wrapper class file",
+)
+@click.option(
+    "-at",
+    "--append_timestamp",
+    is_flag=True, show_default=True, default=True, help="append timestamp to experiment directory"
+)
+def main(config_path, wrapper_path, wrapper_name, append_timestamp):
+    module_name = "user_wrapper"
+    spec = importlib.util.spec_from_file_location(module_name, wrapper_path)
+
+    user_wrapper = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = user_wrapper
+    spec.loader.exec_module(user_wrapper)
+
+    wrapper_cls = getattr(user_wrapper, wrapper_name)
+    print(user_wrapper)
+    print(wrapper_cls)
+
+    controller = Controller(config_path=config_path, wrapper=wrapper_cls)
+    controller.run(append_timestamp=append_timestamp)
+
+
+if __name__ == "__main__":
+    main()

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -1,2 +1,46 @@
+import logging
+from pathlib import Path
+import time
+import datetime as dt
+
+from boa.ax_instantiation_utils import get_experiment, get_scheduler
+from boa.runner import WrappedJobRunner
+from boa.wrapper_utils import load_jsonlike, make_experiment_dir
+from boa.utils import get_dictionary_from_callable
+
+
+
 class Controller:
-    pass
+    def __init__(self, config_path, wrapper):
+        self.config_path = config_path
+        self.wrapper = wrapper
+
+        self.config = None
+
+    def run(self, append_timestamp):
+        start = time.time()
+
+        wrapper = self.wrapper()
+        load_config_kwargs = get_dictionary_from_callable(
+            wrapper.load_config, dict(config_path=self.config_path, append_timestamp=append_timestamp))
+        config = wrapper.load_config(**load_config_kwargs)
+
+        log_format = "%(levelname)s %(asctime)s - %(message)s"
+        logging.basicConfig(
+            filename=Path(wrapper.experiment_dir) / "optimization.log",
+            filemode="w",
+            format=log_format,
+            level=logging.DEBUG,
+        )
+        logging.getLogger().addHandler(logging.StreamHandler())
+        logger = logging.getLogger(__file__)
+        logger.info("Start time: %s", dt.datetime.now().strftime("%Y%m%dT%H%M%S"))
+
+        experiment = get_experiment(config, WrappedJobRunner(wrapper=wrapper), wrapper)
+        scheduler = get_scheduler(experiment, config=config)
+
+        try:
+            scheduler.run_all_trials()
+        finally:
+            logging.info("\nTrials completed! Total run time: %d", time.time() - start)
+        return scheduler

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -1,13 +1,11 @@
-import logging
-from pathlib import Path
-import time
 import datetime as dt
+import logging
+import time
+from pathlib import Path
 
 from boa.ax_instantiation_utils import get_experiment, get_scheduler
 from boa.runner import WrappedJobRunner
-from boa.wrapper_utils import load_jsonlike, make_experiment_dir
 from boa.utils import get_dictionary_from_callable
-
 
 
 class Controller:
@@ -22,7 +20,8 @@ class Controller:
 
         wrapper = self.wrapper()
         load_config_kwargs = get_dictionary_from_callable(
-            wrapper.load_config, dict(config_path=self.config_path, append_timestamp=append_timestamp))
+            wrapper.load_config, dict(config_path=self.config_path, append_timestamp=append_timestamp)
+        )
         config = wrapper.load_config(**load_config_kwargs)
 
         log_format = "%(levelname)s %(asctime)s - %(message)s"

--- a/boa/instantiation_base.py
+++ b/boa/instantiation_base.py
@@ -30,6 +30,7 @@ class BoaInstantiationBase(InstantiationBase):
     @classmethod
     def get_metric_from_obj_config(cls, metric_opts, **kwargs):
         if metric_opts.get("minimize"):
+            # TODO if you do scalarized and need to maximize one, this breaks
             kwargs["lower_is_better"] = metric_opts["minimize"]
         metric = get_metric_from_config(metric_opts, **kwargs)
         return metric

--- a/boa/metaclasses.py
+++ b/boa/metaclasses.py
@@ -18,7 +18,9 @@ def write_exception_to_log(func):
         try:
             return func(*args, **kwargs)
         except Exception:
-            logger.warning("Exception encountered in %s. Traceback: %s", func.__name__, traceback.format_exc())
+            logger.warning(
+                "Boa Wrapper Exception encountered in %s. Traceback: %s", func.__name__, traceback.format_exc()
+            )
 
             raise
 

--- a/boa/metrics/metrics.py
+++ b/boa/metrics/metrics.py
@@ -339,6 +339,7 @@ class METRICS:
     Defaults to minimizization, if you want to maximize,
     specify lower_is_better: False or minimize: False in your configuration
     """
+    mean = Mean
     NRMSE = generic_closure(
         close_around=ModularMetric,
         metric_to_eval=normalized_root_mean_squared_error_,

--- a/boa/test_scripts/run_branin.py
+++ b/boa/test_scripts/run_branin.py
@@ -14,13 +14,7 @@ try:
 except ImportError:
     from .wrappers import Wrapper
 
-from boa import (
-    WrappedJobRunner,
-    get_experiment,
-    get_scheduler,
-    load_yaml,
-    make_experiment_dir,
-)
+from boa import WrappedJobRunner, get_experiment, get_scheduler
 
 
 @click.command()

--- a/boa/test_scripts/run_branin.py
+++ b/boa/test_scripts/run_branin.py
@@ -10,15 +10,14 @@ import click
 from ax.service.utils.report_utils import exp_to_df
 
 try:
-    from wrappers import TestWrapper
+    from wrappers import Wrapper
 except ImportError:
-    from .wrappers import TestWrapper
+    from .wrappers import Wrapper
 
 from boa import (
     WrappedJobRunner,
     get_experiment,
     get_scheduler,
-    get_synth_func,
     load_yaml,
     make_experiment_dir,
 )
@@ -36,14 +35,9 @@ def main(output_dir):
 def run_opt(output_dir):
     config_file = Path(__file__).parent / "synth_func_config.yaml"
     start = time.time()
-    config = load_yaml(config_file)  # Read experiment config'
-    experiment_dir = make_experiment_dir(output_dir, config["optimization_options"]["experiment"]["name"])
-    # setup the paramb bounds based on the synth func bounds and synth func number of params
-    function = get_synth_func(config["model_options"]["function"])
-    config["parameters"] = [
-        {"bounds": list(param), "name": f"x{i}", "type": "range", "value_type": "float"}
-        for i, param in enumerate(function.domain)
-    ]
+    wrapper = Wrapper()
+    config = wrapper.load_config(config_path=config_file, working_dir=output_dir)
+    experiment_dir = wrapper.experiment_dir
     # Copy the experiment config to the experiment directory
     shutil.copyfile(config_file, experiment_dir / Path(config_file).name)
     log_format = "%(levelname)s %(asctime)s - %(message)s"
@@ -56,11 +50,7 @@ def run_opt(output_dir):
     logging.getLogger().addHandler(logging.StreamHandler())
     logger = logging.getLogger(__file__)
     logger.info("Start time: %s", dt.datetime.now().strftime("%Y%m%dT%H%M%S"))
-    wrapper = TestWrapper(
-        ex_settings=config["optimization_options"],
-        experiment_dir=experiment_dir,
-        model_settings=config["model_options"],
-    )
+
     experiment = get_experiment(config, WrappedJobRunner(wrapper=wrapper), wrapper)
     scheduler = get_scheduler(experiment, config=config)
     scheduler.run_all_trials()

--- a/boa/test_scripts/synth_func_cli.py
+++ b/boa/test_scripts/synth_func_cli.py
@@ -28,19 +28,13 @@ from boa import get_synth_func
     default=0.1,
     help="standard deviation of generated data",
 )
-@click.option(
-    "-fn",
-    "--function",
-    type=str,
-    default="hartmann6",
-    help="name of synthetic function",
-)
+
 @click.argument("xs", nargs=-1, type=click.FLOAT)
-def main(output_dir: Path, input_size, standard_dev, function, xs):
-    synthetic_func = get_synth_func(function)
+def main(output_dir: Path, input_size, standard_dev, xs):
+    synthetic_func = get_synth_func("branin")
     rng = default_rng()
     X = rng.normal(loc=xs, scale=standard_dev, size=(input_size, len(xs)))
-    results = dict(input=X.tolist(), output=synthetic_func(X).tolist(), metric_name=function)
+    results = dict(input=X.tolist(), output=synthetic_func(X).tolist(), metric_name="branin")
     with open(output_dir / "output.json", "w") as outfile:
         json.dump(results, outfile, indent=4)
     print(f"saved results: {results} to {output_dir / 'output.json'}")

--- a/boa/test_scripts/synth_func_cli.py
+++ b/boa/test_scripts/synth_func_cli.py
@@ -28,7 +28,6 @@ from boa import get_synth_func
     default=0.1,
     help="standard deviation of generated data",
 )
-
 @click.argument("xs", nargs=-1, type=click.FLOAT)
 def main(output_dir: Path, input_size, standard_dev, xs):
     synthetic_func = get_synth_func("branin")

--- a/boa/test_scripts/synth_func_config.yaml
+++ b/boa/test_scripts/synth_func_config.yaml
@@ -15,6 +15,16 @@ optimization_options:
     experiment:
         name: "test_experiment"
 
+parameters:
+    x0:
+        'bounds': [ -5, 10 ]
+        'type': 'range'
+        'value_type': 'float'
+    x1:
+        'bounds': [ 0, 15 ]
+        'type': 'range'
+        'value_type': 'float'
+
 model_options:
     input_size: 15
     function: branin

--- a/boa/test_scripts/wrappers.py
+++ b/boa/test_scripts/wrappers.py
@@ -15,14 +15,8 @@ from boa import (
 from boa.definitions import TEST_SCRIPTS_DIR
 
 
-class TestWrapper(BaseWrapper):
+class Wrapper(BaseWrapper):
     _processes = []
-
-    def __init__(self, ex_settings, experiment_dir, model_settings):
-        self.ex_settings = ex_settings
-        self.experiment_dir = experiment_dir
-        self.model_settings = model_settings
-
     @cd_and_cd_back_dec(path=TEST_SCRIPTS_DIR)
     def run_model(self, trial: Trial):
         trial_dir = make_trial_dir(self.experiment_dir, trial.index).resolve()
@@ -35,7 +29,6 @@ class TestWrapper(BaseWrapper):
             f"python synth_func_cli.py --output_dir {trial_dir}"
             f" --standard_dev {self.ex_settings['objective_options']['objectives'][0]['noise_sd']}"
             f" --input_size {self.model_settings['input_size']}"
-            f" --function {self.model_settings['function']}"
             f" -- {' '.join(str(val) for val in trial.arm.parameters.values())}"
         )
 
@@ -62,12 +55,12 @@ class TestWrapper(BaseWrapper):
         return dict(
             y_true=np.full(
                 self.model_settings["input_size"],
-                get_synth_func(self.model_settings["function"]).fmin,
+                get_synth_func("branin").fmin,
             ),
             y_pred=data["output"],
         )
 
 
 def exit_handler():
-    for process in TestWrapper._processes:
+    for process in Wrapper._processes:
         process.kill()

--- a/boa/test_scripts/wrappers.py
+++ b/boa/test_scripts/wrappers.py
@@ -17,6 +17,7 @@ from boa.definitions import TEST_SCRIPTS_DIR
 
 class Wrapper(BaseWrapper):
     _processes = []
+
     @cd_and_cd_back_dec(path=TEST_SCRIPTS_DIR)
     def run_model(self, trial: Trial):
         trial_dir = make_trial_dir(self.experiment_dir, trial.index).resolve()

--- a/boa/wrapper.py
+++ b/boa/wrapper.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from ax.core.base_trial import BaseTrial
 
 from boa.metaclasses import WrapperRegister
-from boa.wrapper_utils import load_jsonlike, normalize_config, make_experiment_dir
+from boa.wrapper_utils import load_jsonlike, make_experiment_dir, normalize_config
 
 
 class BaseWrapper(metaclass=WrapperRegister):
@@ -56,16 +56,14 @@ class BaseWrapper(metaclass=WrapperRegister):
 
         experiment_name = self.ex_settings["experiment"]["name"]
         experiment_dir = make_experiment_dir(
-            working_dir=working_dir,
-            experiment_name=experiment_name,
-            append_timestamp=append_timestamp)
+            working_dir=working_dir, experiment_name=experiment_name, append_timestamp=append_timestamp
+        )
 
         self.ex_settings["working_dir"] = working_dir
         self.ex_settings["experiment_dir"] = experiment_dir
         self.experiment_dir = experiment_dir
 
         return self.config
-
 
     def write_configs(self, trial: BaseTrial) -> None:
         """

--- a/boa/wrapper_utils.py
+++ b/boa/wrapper_utils.py
@@ -157,8 +157,9 @@ def normalize_config(
     config["optimization_options"] = config.get("optimization_options", {})
     for key in ["experiment", "generation_strategy", "scheduler"]:
         config["optimization_options"][key] = config["optimization_options"].get(key, {})
-    config["optimization_options"]["experiment"]["name"] = config[
-        "optimization_options"]["experiment"].get("name", get_dt_now_as_str())
+    config["optimization_options"]["experiment"]["name"] = config["optimization_options"]["experiment"].get(
+        "name", get_dt_now_as_str()
+    )
 
     if parameter_keys:
         parameters, mapping = wpr_params_to_boa(config, parameter_keys)

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
             "sphinx",
             "myst-nb",
             "pydata-sphinx-theme",
-            "sphinxext-remoteliteralinclude @ git+https://github.com/madeline-scyphers/sphinxext-remoteliteralinclude.git@bugfix/pyobject-fix",  # noqa
+            "sphinxext-remoteliteralinclude",
         ],
         "examples": ["jupyter", "hvplot"],
     },

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
             "black[jupyter]",
             "isort",
             "flake8",
-            "flakeheaven",
+            "flakeheaven>=3.0.0",
             "pytest",
             "invoke",
             "setuptools_scm",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,13 @@ from pathlib import Path
 
 import pytest
 
+import boa.__main__ as dunder_main
+import boa.test_scripts.run_branin as run_branin
 from boa import cd_and_cd_back, load_yaml
-from boa.test_scripts.run_branin import main
+
+ROOT = Path(__file__).parent.parent
+TEST_DIR = ROOT / "tests"
+TEST_CONFIG_DIR = TEST_DIR / "test_configs"
 
 
 @pytest.fixture
@@ -70,5 +75,28 @@ def cd_to_root_and_back_session():
 @pytest.fixture(scope="session")
 def script_main_run(tmp_path_factory, cd_to_root_and_back_session):
     output_dir = tmp_path_factory.mktemp("output")
-    # yield main.callback(["--output_dir", output_dir], standalone_mode=False)
-    yield main.callback(output_dir)
+    yield run_branin.main.callback(output_dir)
+
+
+@pytest.fixture(scope="session")
+def script_main_run(tmp_path_factory, cd_to_root_and_back_session):
+    output_dir = tmp_path_factory.mktemp("output")
+    yield run_branin.main.callback(output_dir)
+
+
+@pytest.fixture(scope="session")
+def stand_alone_opt_package_run(tmp_path_factory, cd_to_root_and_back_session):
+    experiment_dir = tmp_path_factory.mktemp("experiment") / "temp"
+
+    config_path = TEST_DIR / "scripts/stand_alone_opt_package/stand_alone_pkg_config.json"
+    wrapper_path = TEST_DIR / "scripts/stand_alone_opt_package/wrapper.py"
+    working_dir = TEST_DIR / "scripts/stand_alone_opt_package"
+
+    args = (
+        f" --config_path {config_path}"
+        f" --wrapper_path {wrapper_path}"
+        " --wrapper_name Wrapper"
+        f" --working_dir {working_dir}"
+        f" --experiment_dir {experiment_dir}"
+    )
+    yield dunder_main.main(args.split(), standalone_mode=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,12 +79,6 @@ def script_main_run(tmp_path_factory, cd_to_root_and_back_session):
 
 
 @pytest.fixture(scope="session")
-def script_main_run(tmp_path_factory, cd_to_root_and_back_session):
-    output_dir = tmp_path_factory.mktemp("output")
-    yield run_branin.main.callback(output_dir)
-
-
-@pytest.fixture(scope="session")
 def stand_alone_opt_package_run(tmp_path_factory, cd_to_root_and_back_session):
     experiment_dir = tmp_path_factory.mktemp("experiment") / "temp"
 

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -1,0 +1,8 @@
+def test_calling_command_line_test_script_doesnt_error_out_and_produces_correct_no_of_trials(
+    stand_alone_opt_package_run,
+):
+    scheduler = stand_alone_opt_package_run
+    wrapper = scheduler.experiment.runner.wrapper
+    config = wrapper.config
+    total_trials = config["optimization_options"]["scheduler"]["total_trials"]
+    assert len(wrapper.data) == total_trials

--- a/tests/scripts/stand_alone_opt_package/stand_alone_model_func.py
+++ b/tests/scripts/stand_alone_opt_package/stand_alone_model_func.py
@@ -1,0 +1,8 @@
+from ax import Trial
+from ax.utils.measurement.synthetic_functions import branin
+
+
+def run_branin_from_trial(trial: Trial) -> float:
+    x0, x1 = trial.arm.parameters.get("x0"), trial.arm.parameters.get("x1")
+    result = branin(x0, x1)
+    return result

--- a/tests/scripts/stand_alone_opt_package/stand_alone_pkg_config.json
+++ b/tests/scripts/stand_alone_opt_package/stand_alone_pkg_config.json
@@ -1,0 +1,69 @@
+{
+  "optimization_options": {
+    "experiment": {
+      "name": "test_experiment"
+    },
+    "generation_strategy": {
+      "steps": [
+        {
+          "model": "SOBOL",
+          "num_trials": 5
+        },
+        {
+          "model": "GPEI",
+          "num_trials": -1
+        }
+      ]
+    },
+    "objective_options": {
+      "objectives": [
+        {
+          "boa_metric": "mean",
+          "name": "mean"
+        }
+      ]
+    },
+    "scheduler": {
+      "total_trials": 15
+    }
+  },
+  "parameter_constraints_orig": [],
+  "parameters": [
+    {
+      "bounds": [
+        -5,
+        10
+      ],
+      "name": "x0",
+      "type": "range",
+      "value_type": "float"
+    },
+    {
+      "bounds": [
+        0,
+        15
+      ],
+      "name": "x1",
+      "type": "range",
+      "value_type": "float"
+    }
+  ],
+  "parameters_orig": {
+    "x0": {
+      "bounds": [
+        -5,
+        10
+      ],
+      "type": "range",
+      "value_type": "float"
+    },
+    "x1": {
+      "bounds": [
+        0,
+        15
+      ],
+      "type": "range",
+      "value_type": "float"
+    }
+  }
+}

--- a/tests/scripts/stand_alone_opt_package/wrapper.py
+++ b/tests/scripts/stand_alone_opt_package/wrapper.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from ax import Trial
+from stand_alone_model_func import run_branin_from_trial
+
+
+class Wrapper:
+    def __init__(self):
+        self.config = None
+        self.model_settings = None
+        self.ex_settings = None
+        self.experiment_dir = None
+
+        self.data = {}
+
+    def load_config(
+        self, config_path: os.PathLike, append_timestamp: bool = True, experiment_dir: os.PathLike = None, **kwargs
+    ):
+        file_path = Path(config_path).expanduser()
+        with open(file_path, "r") as f:
+            self.config = json.load(f)
+
+        self.ex_settings = self.config["optimization_options"]
+        self.model_settings = self.config.get("model_options", {})
+
+        if experiment_dir:
+            self.ex_settings["experiment_dir"] = str(experiment_dir)
+            self.experiment_dir = Path(experiment_dir)
+            self.experiment_dir.mkdir()
+            return self.config
+
+        working_dir = {**self.ex_settings, **kwargs}.get("working_dir")
+        if not working_dir:
+            working_dir = Path.cwd()
+
+        experiment_name = self.ex_settings["experiment"]["name"]
+
+        experiment_dir = Path(working_dir).expanduser() / f"{experiment_name}"
+        experiment_dir.mkdir()
+
+        self.ex_settings["working_dir"] = working_dir
+        self.ex_settings["experiment_dir"] = experiment_dir
+        self.experiment_dir = experiment_dir
+
+        return self.config
+
+    def write_configs(self, trial: Trial) -> None:
+        pass
+
+    def run_model(self, trial: Trial) -> None:
+        self.data[trial.index] = run_branin_from_trial(trial)
+
+    def set_trial_status(self, trial: Trial) -> None:
+        data_exists = self.data.get(trial.index)
+        if data_exists:
+            trial.mark_completed()
+
+    def fetch_trial_data(self, trial: Trial, metric_properties: dict, metric_name: str, *args, **kwargs) -> dict:
+        return dict(a=self.data[trial.index])

--- a/tests/test_configs/test_config_param_parse.yaml
+++ b/tests/test_configs/test_config_param_parse.yaml
@@ -37,4 +37,3 @@ params2:
           x2:
               type: fixed
               value: 0.5
-

--- a/tests/test_configs/test_config_soo.yaml
+++ b/tests/test_configs/test_config_soo.yaml
@@ -1,4 +1,7 @@
 # ScalarizedObjective Optimization config
+
+# WARNING if you use scalarized and you maximize the whole objective, but minimize any single metric, it currently breaks
+
 optimization_options:
   objective_options:  # can also use the key soo
     objectives:


### PR DESCRIPTION
# Summary

## Added
- [Add a `__main__` and Controller class with a run method to allow command line passing of the wrapper path, wrapper class name, and other things to command line, so that you don't have to write your own run script if you follow a normal wrapper pattern, then it should work and you should be able to just pass these in as command line arguments and it will do the run script for you (assuming you don't need a more customized version of a run script)](https://github.com/madeline-scyphers/boa/commit/e2aeb4dd07dc578c2d544ae05da4ec563aa0deec)
- [Add ability to set working dir for boa __main__](https://github.com/madeline-scyphers/boa/commit/26ef8a8794d9073494173d9b31453320c92de7b2)
  - This fixes situations where the wrapper it is importing also imports from its own directory (in python).
So now it will set the working dir, add it to the path for python look ups and now imports in the wrapper file
should work properly.
- [Add standalone pkg to test with dunder main](https://github.com/madeline-scyphers/boa/commit/c954c58fd4e75507205e31d646238bd7ed1321cc)
  - Add a stand alone sub package that needs to be ran inside its subdirectory with no reliance on boa that can be called with __main__ to check its pathing stuff properly.