### PR TITLE
Add __main__.py script to run python wrapper

### DIFF
--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -37,7 +37,7 @@ from boa.wrapper_utils import cd_and_cd_back, load_jsonlike
     " instead of relative to the config file location (the default)"
     " ex:"
     " given working_dir=path/to/dir"
-    " if you don't pass --rel_to_her then path/to/dir is defined in terms of where your config file is"
+    " if you don't pass --rel_to_here then path/to/dir is defined in terms of where your config file is"
     " if you do pass --rel_to_here then path/to/dir is defined in terms of where you launch boa from",
 )
 def main(config_path, temporary_dir, rel_to_here):

--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -35,11 +35,11 @@ from boa.wrapper_utils import cd_and_cd_back, load_jsonlike
     show_default=True,
     default=False,
     help="Define all path and dir options in your config file relative to where boa is launch from"
-         " instead of relative to the config file location (the default)"
-         " ex:"
-         " given working_dir=path/to/dir"
-         " if you don't pass --rel_to_her then path/to/dir is defined in terms of where your config file is"
-         " if you do pass --rel_to_here then path/to/dir is defined in terms of where you launch boa from"
+    " instead of relative to the config file location (the default)"
+    " ex:"
+    " given working_dir=path/to/dir"
+    " if you don't pass --rel_to_her then path/to/dir is defined in terms of where your config file is"
+    " if you do pass --rel_to_here then path/to/dir is defined in terms of where you launch boa from",
 )
 def main(config_path, temporary_dir, rel_to_here):
     if temporary_dir:

--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -25,8 +25,7 @@ from boa.wrapper_utils import cd_and_cd_back, load_jsonlike
     help="Modify/add to the config file a temporary directory as the experiment_dir that will get deleted after running"
     " (useful for testing)."
     " This requires your Wrapper to have the ability to take experiment_dir as an argument"
-    " to ``load_config``. The default ``load_config`` does support this."
-    " --experiment_dir and --temp_dir can't both be used.",
+    " to ``load_config``. The default ``load_config`` does support this.",
 )
 @click.option(
     "-rel",

--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -1,0 +1,101 @@
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+import click
+
+from boa.controller import Controller
+from boa.wrapper_utils import cd_and_cd_back
+
+
+@click.command()
+@click.option(
+    "-c",
+    "--config_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to configuration YAML file.",
+)
+@click.option(
+    "-w",
+    "--wrapper_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=Path(__file__).resolve().parent / "opt_config.yaml",
+    help="Path to file with boa wrapper class",
+)
+@click.option(
+    "-wn",
+    "--wrapper_name",
+    type=str,
+    default="Wrapper",
+    help="Name of wrapper class in boa wrapper class file",
+)
+@click.option(
+    "-d",
+    "--working_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Path to working dir to to cd to. "
+    "Can be necessary for certain languages and projects that need to be in a certain directory for imports.",
+)
+@click.option(
+    "-at",
+    "--append_timestamp",
+    is_flag=True,
+    show_default=True,
+    default=True,
+    help="Whether to append a timestamp to the end of the experiment directory to ensure uniqueness",
+)
+@click.option(
+    "-o",
+    "--experiment_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Modify/add to the config file the passed in experiment_dir for use downstream."
+    " This requires your Wrapper to have the ability to take experiment_dir as an argument"
+    " to ``load_config``. The default ``load_config`` does support this."
+    " --experiment_dir and --temp_dir can't both be used.",
+)
+@click.option(
+    "-td",
+    "--temporary_dir",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Modify/add to the config file a temporary directory as the experiment_dir that will get deleted after running"
+    " (useful for testing)."
+    " This requires your Wrapper to have the ability to take experiment_dir as an argument"
+    " to ``load_config``. The default ``load_config`` does support this."
+    " --experiment_dir and --temp_dir can't both be used.",
+)
+def main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir, temporary_dir):
+    if temporary_dir:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            experiment_dir = Path(temp_dir) / "temp"
+            return _main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir)
+    return _main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir)
+
+
+def _main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir):
+    if working_dir:
+        sys.path.append(str(working_dir))
+    with cd_and_cd_back(working_dir):
+        # create a module spec from a file location so we can then load that module
+        module_name = "user_wrapper"
+        spec = importlib.util.spec_from_file_location(module_name, wrapper_path)
+        # create that module from that spec from above
+        user_wrapper = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = user_wrapper
+        # execute the loading and importing of the module
+        spec.loader.exec_module(user_wrapper)
+
+        # since we just loaded the module where the wrapper class is, we can now load it
+        wrapper_cls = getattr(user_wrapper, wrapper_name)
+
+        controller = Controller(config_path=config_path, wrapper=wrapper_cls)
+        scheduler = controller.run(append_timestamp=append_timestamp, experiment_dir=experiment_dir)
+        return scheduler
+
+
+if __name__ == "__main__":
+    main()

--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -6,55 +6,15 @@ from pathlib import Path
 import click
 
 from boa.controller import Controller
-from boa.wrapper_utils import cd_and_cd_back
+from boa.wrapper_utils import cd_and_cd_back, load_jsonlike
 
 
 @click.command()
 @click.option(
     "-c",
     "--config_path",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    type=click.Path(dir_okay=False, path_type=Path),
     help="Path to configuration YAML file.",
-)
-@click.option(
-    "-w",
-    "--wrapper_path",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
-    default=Path(__file__).resolve().parent / "opt_config.yaml",
-    help="Path to file with boa wrapper class",
-)
-@click.option(
-    "-wn",
-    "--wrapper_name",
-    type=str,
-    default="Wrapper",
-    help="Name of wrapper class in boa wrapper class file",
-)
-@click.option(
-    "-d",
-    "--working_dir",
-    type=click.Path(file_okay=False, path_type=Path),
-    default=None,
-    help="Path to working dir to to cd to. "
-    "Can be necessary for certain languages and projects that need to be in a certain directory for imports.",
-)
-@click.option(
-    "-at",
-    "--append_timestamp",
-    is_flag=True,
-    show_default=True,
-    default=True,
-    help="Whether to append a timestamp to the end of the experiment directory to ensure uniqueness",
-)
-@click.option(
-    "-o",
-    "--experiment_dir",
-    type=click.Path(file_okay=False, path_type=Path),
-    default=None,
-    help="Modify/add to the config file the passed in experiment_dir for use downstream."
-    " This requires your Wrapper to have the ability to take experiment_dir as an argument"
-    " to ``load_config``. The default ``load_config`` does support this."
-    " --experiment_dir and --temp_dir can't both be used.",
 )
 @click.option(
     "-td",
@@ -68,31 +28,48 @@ from boa.wrapper_utils import cd_and_cd_back
     " to ``load_config``. The default ``load_config`` does support this."
     " --experiment_dir and --temp_dir can't both be used.",
 )
-def main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir, temporary_dir):
+# --rel_to_here
+def main(config_path, temporary_dir, rel_to_here=False):
     if temporary_dir:
         with tempfile.TemporaryDirectory() as temp_dir:
             experiment_dir = Path(temp_dir) / "temp"
-            return _main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir)
-    return _main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir)
+            return _main(config_path, rel_to_here, experiment_dir)
+    return _main(config_path, rel_to_here=rel_to_here)
 
 
-def _main(config_path, wrapper_path, wrapper_name, working_dir, append_timestamp, experiment_dir):
+def _main(config_path, rel_to_here, experiment_dir=None):
+    config = load_jsonlike(config_path, normalize=False)
+
+    script_options = config.get("script_options", {})
+    wrapper_path = script_options.get("wrapper_path")
+    wrapper_name = script_options.get("wrapper_name", "Wrapper")
+    working_dir = script_options.get("working_dir")
+    experiment_dir = experiment_dir or script_options.get("experiment_dir")
+    append_timestamp = script_options.get("append_timestamp", True)
+
+    config_path = Path(config_path).resolve()
+    wrapper_path = Path(wrapper_path).resolve() if wrapper_path else wrapper_path
+    working_dir = Path(working_dir).resolve() if working_dir else working_dir
+
     if working_dir:
         sys.path.append(str(working_dir))
     with cd_and_cd_back(working_dir):
-        # create a module spec from a file location so we can then load that module
-        module_name = "user_wrapper"
-        spec = importlib.util.spec_from_file_location(module_name, wrapper_path)
-        # create that module from that spec from above
-        user_wrapper = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = user_wrapper
-        # execute the loading and importing of the module
-        spec.loader.exec_module(user_wrapper)
+        if wrapper_path:
+            # create a module spec from a file location so we can then load that module
+            module_name = "user_wrapper"
+            spec = importlib.util.spec_from_file_location(module_name, wrapper_path)
+            # create that module from that spec from above
+            user_wrapper = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = user_wrapper
+            # execute the loading and importing of the module
+            spec.loader.exec_module(user_wrapper)
 
-        # since we just loaded the module where the wrapper class is, we can now load it
-        wrapper_cls = getattr(user_wrapper, wrapper_name)
+            # since we just loaded the module where the wrapper class is, we can now load it
+            WrapperCls = getattr(user_wrapper, wrapper_name)
+        else:
+            from boa.wrapper import BaseWrapper as WrapperCls
 
-        controller = Controller(config_path=config_path, wrapper=wrapper_cls)
+        controller = Controller(config_path=config_path, wrapper=WrapperCls)
         scheduler = controller.run(append_timestamp=append_timestamp, experiment_dir=experiment_dir)
         return scheduler
 

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -1,4 +1,3 @@
-import datetime as dt
 import logging
 import time
 from pathlib import Path
@@ -7,7 +6,7 @@ from boa.ax_instantiation_utils import get_experiment, get_scheduler
 from boa.runner import WrappedJobRunner
 from boa.storage import scheduler_to_json_file
 from boa.utils import get_dictionary_from_callable
-
+from boa.wrapper_utils import get_dt_now_as_str
 
 class Controller:
     def __init__(self, config_path, wrapper):
@@ -38,7 +37,7 @@ class Controller:
         )
         logging.getLogger().addHandler(logging.StreamHandler())
         logger = logging.getLogger(__file__)
-        logger.info("Start time: %s", dt.datetime.now().strftime("%Y%m%dT%H%M%S"))
+        logger.info("Start time: %s", get_dt_now_as_str())
 
         experiment = get_experiment(config, WrappedJobRunner(wrapper=wrapper), wrapper)
         scheduler = get_scheduler(experiment, config=config)

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -8,6 +8,7 @@ from boa.storage import scheduler_to_json_file
 from boa.utils import get_dictionary_from_callable
 from boa.wrapper_utils import get_dt_now_as_str
 
+
 class Controller:
     def __init__(self, config_path, wrapper):
         self.config_path = config_path

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -19,16 +19,15 @@ class Controller:
     def run(self, append_timestamp, experiment_dir, **kwargs):
         start = time.time()
 
-        wrapper = self.wrapper()
-
         kwargs["config_path"] = self.config_path
         if experiment_dir:
             kwargs["experiment_dir"] = experiment_dir
         if append_timestamp is not None:
             kwargs["append_timestamp"] = append_timestamp
 
-        load_config_kwargs = get_dictionary_from_callable(wrapper.load_config, kwargs)
-        config = wrapper.load_config(**load_config_kwargs)
+        load_config_kwargs = get_dictionary_from_callable(self.wrapper.load_config, kwargs)
+        wrapper = self.wrapper(**load_config_kwargs)
+        config = wrapper.config
 
         log_format = "%(levelname)s %(asctime)s - %(message)s"
         logging.basicConfig(

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -1,2 +1,56 @@
+import datetime as dt
+import logging
+import time
+from pathlib import Path
+
+from boa.ax_instantiation_utils import get_experiment, get_scheduler
+from boa.runner import WrappedJobRunner
+from boa.storage import scheduler_to_json_file
+from boa.utils import get_dictionary_from_callable
+
+
 class Controller:
-    pass
+    def __init__(self, config_path, wrapper):
+        self.config_path = config_path
+        self.wrapper = wrapper
+
+        self.config = None
+
+    def run(self, append_timestamp, experiment_dir, **kwargs):
+        start = time.time()
+
+        wrapper = self.wrapper()
+
+        kwargs["config_path"] = self.config_path
+        if experiment_dir:
+            kwargs["experiment_dir"] = experiment_dir
+        if append_timestamp is not None:
+            kwargs["append_timestamp"] = append_timestamp
+
+        load_config_kwargs = get_dictionary_from_callable(wrapper.load_config, kwargs)
+        config = wrapper.load_config(**load_config_kwargs)
+
+        log_format = "%(levelname)s %(asctime)s - %(message)s"
+        logging.basicConfig(
+            filename=Path(wrapper.experiment_dir) / "optimization.log",
+            filemode="w",
+            format=log_format,
+            level=logging.DEBUG,
+        )
+        logging.getLogger().addHandler(logging.StreamHandler())
+        logger = logging.getLogger(__file__)
+        logger.info("Start time: %s", dt.datetime.now().strftime("%Y%m%dT%H%M%S"))
+
+        experiment = get_experiment(config, WrappedJobRunner(wrapper=wrapper), wrapper)
+        scheduler = get_scheduler(experiment, config=config)
+
+        try:
+            scheduler.run_all_trials()
+        finally:
+            logging.info("\nTrials completed! Total run time: %d", time.time() - start)
+        try:
+            experiment_dir = wrapper.experiment_dir
+            scheduler_to_json_file(scheduler, experiment_dir / "scheduler.json")
+        except Exception as e:
+            logging.exception("failed to save scheduler to json! Reason: %s" % repr(e))
+        return scheduler

--- a/boa/metaclasses.py
+++ b/boa/metaclasses.py
@@ -18,8 +18,9 @@ def write_exception_to_log(func):
         try:
             return func(*args, **kwargs)
         except Exception:
-            logger.warning("Exception encountered in %s. Traceback: %s", func.__name__, traceback.format_exc())
-
+            logger.warning(
+                "Boa Wrapper Exception encountered in %s. Traceback: %s", func.__name__, traceback.format_exc()
+            )
             raise
 
     return wrapper

--- a/boa/metrics/metrics.py
+++ b/boa/metrics/metrics.py
@@ -339,6 +339,7 @@ class METRICS:
     Defaults to minimizization, if you want to maximize,
     specify lower_is_better: False or minimize: False in your configuration
     """
+    mean = Mean
     NRMSE = generic_closure(
         close_around=ModularMetric,
         metric_to_eval=normalized_root_mean_squared_error_,

--- a/boa/wrapper.py
+++ b/boa/wrapper.py
@@ -19,7 +19,13 @@ class BaseWrapper(metaclass=WrapperRegister):
         self.experiment_dir = None
 
         if config_path:
-            self.config = self.load_config(config_path, *args, **kwargs)
+            self.config = None
+            config = self.load_config(config_path, *args, **kwargs)
+            # if load_config returns something, set to self.config
+            # if users overwrite load_config and don't return anything, we don't
+            # want to set it to self.config if they set it in load_config
+            if config is not None:
+                self.config = config
             self.mk_experiment_dir(*args, **kwargs)
 
     def load_config(self, config_path: os.PathLike, *args, **kwargs):

--- a/boa/wrapper_utils.py
+++ b/boa/wrapper_utils.py
@@ -171,20 +171,23 @@ def normalize_config(
     config["parameters_orig"] = deepcopy(config.get("parameters", {}))
     config["parameter_constraints_orig"] = deepcopy(config.get("parameter_constraints", []))
 
-    search_space_parameters = []
-    for param in config.get("parameters", {}).keys():
-        d = deepcopy(config["parameters"][param])
-        d["name"] = param  # Add "name" attribute for each parameter
-        # remove bounds on fixed params
-        if d.get("type", "") == "fixed" and "bounds" in d:
-            del d["bounds"]
-        # Remove value on range params
-        if d.get("type", "") == "range" and "value" in d:
-            del d["value"]
+    parameters = config.get("parameters", {})
+    # parameters in the form of name: options, normalize to a list form: [{name: x, bounds: (1, 2), etc}]
+    if isinstance(parameters, dict):
+        search_space_parameters = []
+        for param in config.get("parameters", {}).keys():
+            d = deepcopy(config["parameters"][param])
+            d["name"] = param  # Add "name" attribute for each parameter
+            # remove bounds on fixed params
+            if d.get("type", "") == "fixed" and "bounds" in d:
+                del d["bounds"]
+            # Remove value on range params
+            if d.get("type", "") == "range" and "value" in d:
+                del d["value"]
 
-        search_space_parameters.append(d)
+            search_space_parameters.append(d)
 
-    config["parameters"] = search_space_parameters
+        config["parameters"] = search_space_parameters
 
     return config
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import json
+import logging
 import sys
 from pathlib import Path
-import logging
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from pathlib import Path
+import logging
 
 import pytest
 
@@ -8,6 +9,8 @@ import boa.__main__ as dunder_main
 import boa.test_scripts.run_branin as run_branin
 from boa import cd_and_cd_back, load_yaml
 from boa.definitions import ROOT
+
+logger = logging.getLogger(__file__)
 
 TEST_DIR = ROOT / "tests"
 TEST_CONFIG_DIR = TEST_DIR / "test_configs"
@@ -107,6 +110,4 @@ def stand_alone_opt_package_run(request, tmp_path_factory, cd_to_root_and_back_s
         config_path = TEST_DIR / "scripts/stand_alone_opt_package/stand_alone_pkg_config.json"
 
     args = f"--config_path {config_path} -td"
-    # remove stand_alone_opt_package from sys.path to test that __main__ re adds it
-    sys.path.remove(str(TEST_DIR / "scripts/stand_alone_opt_package/"))
     yield dunder_main.main(args.split(), standalone_mode=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,8 +82,5 @@ def script_main_run(tmp_path_factory, cd_to_root_and_back_session):
 def stand_alone_opt_package_run(tmp_path_factory, cd_to_root_and_back_session):
     config_path = TEST_DIR / "scripts/stand_alone_opt_package/stand_alone_pkg_config.json"
 
-    args = (
-        f" --config_path {config_path}"
-        f" -td"
-    )
+    args = f" --config_path {config_path}" f" -td"
     yield dunder_main.main(args.split(), standalone_mode=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,13 @@ from pathlib import Path
 
 import pytest
 
+import boa.__main__ as dunder_main
+import boa.test_scripts.run_branin as run_branin
 from boa import cd_and_cd_back, load_yaml
-from boa.test_scripts.run_branin import main
+
+ROOT = Path(__file__).parent.parent
+TEST_DIR = ROOT / "tests"
+TEST_CONFIG_DIR = TEST_DIR / "test_configs"
 
 
 @pytest.fixture
@@ -70,5 +75,22 @@ def cd_to_root_and_back_session():
 @pytest.fixture(scope="session")
 def script_main_run(tmp_path_factory, cd_to_root_and_back_session):
     output_dir = tmp_path_factory.mktemp("output")
-    # yield main.callback(["--output_dir", output_dir], standalone_mode=False)
-    yield main.callback(output_dir)
+    yield run_branin.main.callback(output_dir)
+
+
+@pytest.fixture(scope="session")
+def stand_alone_opt_package_run(tmp_path_factory, cd_to_root_and_back_session):
+    experiment_dir = tmp_path_factory.mktemp("experiment") / "temp"
+
+    config_path = TEST_DIR / "scripts/stand_alone_opt_package/stand_alone_pkg_config.json"
+    wrapper_path = TEST_DIR / "scripts/stand_alone_opt_package/wrapper.py"
+    working_dir = TEST_DIR / "scripts/stand_alone_opt_package"
+
+    args = (
+        f" --config_path {config_path}"
+        f" --wrapper_path {wrapper_path}"
+        " --wrapper_name Wrapper"
+        f" --working_dir {working_dir}"
+        f" --experiment_dir {experiment_dir}"
+    )
+    yield dunder_main.main(args.split(), standalone_mode=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,48 +5,48 @@ import pytest
 import boa.__main__ as dunder_main
 import boa.test_scripts.run_branin as run_branin
 from boa import cd_and_cd_back, load_yaml
+from boa.definitions import ROOT
 
-ROOT = Path(__file__).parent.parent
 TEST_DIR = ROOT / "tests"
 TEST_CONFIG_DIR = TEST_DIR / "test_configs"
 
 
 @pytest.fixture
 def synth_config():
-    config_path = Path(__file__).parent / "test_configs/test_config_synth.yaml"
+    config_path = TEST_CONFIG_DIR / "test_config_synth.yaml"
     return load_yaml(config_path)
 
 
 @pytest.fixture
 def metric_config():
-    config_path = Path(__file__).parent / "test_configs/test_config_metric.yaml"
+    config_path = TEST_CONFIG_DIR / "test_config_metric.yaml"
     return load_yaml(config_path)
 
 
 @pytest.fixture
 def gen_strat1_config():
-    config_path = Path(__file__).parent / "test_configs/test_config_gen_strat1.yaml"
+    config_path = TEST_CONFIG_DIR / "test_config_gen_strat1.yaml"
     return load_yaml(config_path)
 
 
 @pytest.fixture
 def soo_config():
     """ScalarizedObjective Optimization config"""
-    config_path = Path(__file__).parent / "test_configs/test_config_soo.yaml"
+    config_path = TEST_CONFIG_DIR / "test_config_soo.yaml"
     return load_yaml(config_path)
 
 
 @pytest.fixture
 def moo_config():
     """MultiObjective Optimization config"""
-    config_path = Path(__file__).parent / "test_configs/test_config_moo.yaml"
+    config_path = TEST_CONFIG_DIR / "test_config_moo.yaml"
     return load_yaml(config_path)
 
 
 @pytest.fixture
 def denormed_param_parse_config():
     """MultiObjective Optimization config"""
-    config_path = Path(__file__).parent / "test_configs/test_config_param_parse.yaml"
+    config_path = TEST_CONFIG_DIR / "test_config_param_parse.yaml"
     return load_yaml(config_path)
 
 
@@ -62,13 +62,13 @@ def metric_optimization_options(metric_config):
 
 @pytest.fixture
 def cd_to_root_and_back():
-    with cd_and_cd_back(Path(__file__).resolve().parent.parent):
+    with cd_and_cd_back(ROOT):
         yield
 
 
 @pytest.fixture(scope="session")
 def cd_to_root_and_back_session():
-    with cd_and_cd_back(Path(__file__).resolve().parent.parent):
+    with cd_and_cd_back(ROOT):
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,17 +80,10 @@ def script_main_run(tmp_path_factory, cd_to_root_and_back_session):
 
 @pytest.fixture(scope="session")
 def stand_alone_opt_package_run(tmp_path_factory, cd_to_root_and_back_session):
-    experiment_dir = tmp_path_factory.mktemp("experiment") / "temp"
-
     config_path = TEST_DIR / "scripts/stand_alone_opt_package/stand_alone_pkg_config.json"
-    wrapper_path = TEST_DIR / "scripts/stand_alone_opt_package/wrapper.py"
-    working_dir = TEST_DIR / "scripts/stand_alone_opt_package"
 
     args = (
         f" --config_path {config_path}"
-        f" --wrapper_path {wrapper_path}"
-        " --wrapper_name Wrapper"
-        f" --working_dir {working_dir}"
-        f" --experiment_dir {experiment_dir}"
+        f" -td"
     )
     yield dunder_main.main(args.split(), standalone_mode=False)

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -1,3 +1,12 @@
+import pytest
+
+
+# parametrize the test to pass in script options in config as relative and absolute paths
+@pytest.mark.parametrize(
+    "stand_alone_opt_package_run",
+    ["relative", "absolute"],
+    indirect=True,
+)
 def test_calling_command_line_test_script_doesnt_error_out_and_produces_correct_no_of_trials(
     stand_alone_opt_package_run,
 ):
@@ -5,4 +14,4 @@ def test_calling_command_line_test_script_doesnt_error_out_and_produces_correct_
     wrapper = scheduler.experiment.runner.wrapper
     config = wrapper.config
     total_trials = config["optimization_options"]["scheduler"]["total_trials"]
-    assert len(wrapper.data) == total_trials
+    assert len(scheduler.experiment.trials) == total_trials

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -1,0 +1,8 @@
+def test_calling_command_line_test_script_doesnt_error_out_and_produces_correct_no_of_trials(
+    stand_alone_opt_package_run,
+):
+    scheduler = stand_alone_opt_package_run
+    wrapper = scheduler.experiment.runner.wrapper
+    config = wrapper.config
+    total_trials = config["optimization_options"]["scheduler"]["total_trials"]
+    assert len(wrapper.data) == total_trials

--- a/tests/scripts/stand_alone_opt_package/stand_alone_model_func.py
+++ b/tests/scripts/stand_alone_opt_package/stand_alone_model_func.py
@@ -1,0 +1,8 @@
+from ax import Trial
+from ax.utils.measurement.synthetic_functions import branin
+
+
+def run_branin_from_trial(trial: Trial) -> float:
+    x0, x1 = trial.arm.parameters.get("x0"), trial.arm.parameters.get("x1")
+    result = branin(x0, x1)
+    return result

--- a/tests/scripts/stand_alone_opt_package/stand_alone_pkg_config.json
+++ b/tests/scripts/stand_alone_opt_package/stand_alone_pkg_config.json
@@ -7,7 +7,7 @@
       "steps": [
         {
           "model": "SOBOL",
-          "num_trials": 5
+          "num_trials": 2
         },
         {
           "model": "GPEI",
@@ -24,7 +24,7 @@
       ]
     },
     "scheduler": {
-      "total_trials": 15
+      "total_trials": 5
     }
   },
   "parameter_constraints_orig": [],

--- a/tests/scripts/stand_alone_opt_package/stand_alone_pkg_config.json
+++ b/tests/scripts/stand_alone_opt_package/stand_alone_pkg_config.json
@@ -1,0 +1,69 @@
+{
+  "optimization_options": {
+    "experiment": {
+      "name": "test_experiment"
+    },
+    "generation_strategy": {
+      "steps": [
+        {
+          "model": "SOBOL",
+          "num_trials": 5
+        },
+        {
+          "model": "GPEI",
+          "num_trials": -1
+        }
+      ]
+    },
+    "objective_options": {
+      "objectives": [
+        {
+          "boa_metric": "mean",
+          "name": "mean"
+        }
+      ]
+    },
+    "scheduler": {
+      "total_trials": 15
+    }
+  },
+  "parameter_constraints_orig": [],
+  "parameters": [
+    {
+      "bounds": [
+        -5,
+        10
+      ],
+      "name": "x0",
+      "type": "range",
+      "value_type": "float"
+    },
+    {
+      "bounds": [
+        0,
+        15
+      ],
+      "name": "x1",
+      "type": "range",
+      "value_type": "float"
+    }
+  ],
+  "parameters_orig": {
+    "x0": {
+      "bounds": [
+        -5,
+        10
+      ],
+      "type": "range",
+      "value_type": "float"
+    },
+    "x1": {
+      "bounds": [
+        0,
+        15
+      ],
+      "type": "range",
+      "value_type": "float"
+    }
+  }
+}

--- a/tests/scripts/stand_alone_opt_package/wrapper.py
+++ b/tests/scripts/stand_alone_opt_package/wrapper.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from ax import Trial
+from stand_alone_model_func import run_branin_from_trial
+
+
+class Wrapper:
+    def __init__(self):
+        self.config = None
+        self.model_settings = None
+        self.ex_settings = None
+        self.experiment_dir = None
+
+        self.data = {}
+
+    def load_config(
+        self, config_path: os.PathLike, append_timestamp: bool = True, experiment_dir: os.PathLike = None, **kwargs
+    ):
+        file_path = Path(config_path).expanduser()
+        with open(file_path, "r") as f:
+            self.config = json.load(f)
+
+        self.ex_settings = self.config["optimization_options"]
+        self.model_settings = self.config.get("model_options", {})
+
+        if experiment_dir:
+            self.ex_settings["experiment_dir"] = str(experiment_dir)
+            self.experiment_dir = Path(experiment_dir)
+            self.experiment_dir.mkdir()
+            return self.config
+
+        working_dir = {**self.ex_settings, **kwargs}.get("working_dir")
+        if not working_dir:
+            working_dir = Path.cwd()
+
+        experiment_name = self.ex_settings["experiment"]["name"]
+
+        experiment_dir = Path(working_dir).expanduser() / f"{experiment_name}"
+        experiment_dir.mkdir()
+
+        self.ex_settings["working_dir"] = working_dir
+        self.ex_settings["experiment_dir"] = experiment_dir
+        self.experiment_dir = experiment_dir
+
+        return self.config
+
+    def write_configs(self, trial: Trial) -> None:
+        pass
+
+    def run_model(self, trial: Trial) -> None:
+        self.data[trial.index] = run_branin_from_trial(trial)
+
+    def set_trial_status(self, trial: Trial) -> None:
+        data_exists = self.data.get(trial.index)
+        if data_exists:
+            trial.mark_completed()
+
+    def fetch_trial_data(self, trial: Trial, metric_properties: dict, metric_name: str, *args, **kwargs) -> dict:
+        return dict(a=self.data[trial.index])

--- a/tests/scripts/stand_alone_opt_package/wrapper.py
+++ b/tests/scripts/stand_alone_opt_package/wrapper.py
@@ -9,13 +9,16 @@ from stand_alone_model_func import run_branin_from_trial
 
 
 class Wrapper:
-    def __init__(self):
+    def __init__(self, config_path: os.PathLike = None, *args, **kwargs):
         self.config = None
         self.model_settings = None
         self.ex_settings = None
         self.experiment_dir = None
 
         self.data = {}
+
+        if config_path:
+            self.config = self.load_config(config_path, *args, **kwargs)
 
     def load_config(
         self, config_path: os.PathLike, append_timestamp: bool = True, experiment_dir: os.PathLike = None, **kwargs

--- a/tests/scripts/stand_alone_opt_package/wrapper.py
+++ b/tests/scripts/stand_alone_opt_package/wrapper.py
@@ -1,58 +1,15 @@
 from __future__ import annotations
 
-import json
-import os
-from pathlib import Path
-
 from ax import Trial
 from stand_alone_model_func import run_branin_from_trial
 
+from boa.wrapper import BaseWrapper
 
-class Wrapper:
-    def __init__(self, config_path: os.PathLike = None, *args, **kwargs):
-        self.config = None
-        self.model_settings = None
-        self.ex_settings = None
-        self.experiment_dir = None
 
+class Wrapper(BaseWrapper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.data = {}
-
-        if config_path:
-            self.config = self.load_config(config_path, *args, **kwargs)
-
-    def load_config(
-        self, config_path: os.PathLike, append_timestamp: bool = True, experiment_dir: os.PathLike = None, **kwargs
-    ):
-        file_path = Path(config_path).expanduser()
-        with open(file_path, "r") as f:
-            self.config = json.load(f)
-
-        self.ex_settings = self.config["optimization_options"]
-        self.model_settings = self.config.get("model_options", {})
-
-        if experiment_dir:
-            self.ex_settings["experiment_dir"] = str(experiment_dir)
-            self.experiment_dir = Path(experiment_dir)
-            self.experiment_dir.mkdir()
-            return self.config
-
-        working_dir = {**self.ex_settings, **kwargs}.get("working_dir")
-        if not working_dir:
-            working_dir = Path.cwd()
-
-        experiment_name = self.ex_settings["experiment"]["name"]
-
-        experiment_dir = Path(working_dir).expanduser() / f"{experiment_name}"
-        experiment_dir.mkdir()
-
-        self.ex_settings["working_dir"] = working_dir
-        self.ex_settings["experiment_dir"] = experiment_dir
-        self.experiment_dir = experiment_dir
-
-        return self.config
-
-    def write_configs(self, trial: Trial) -> None:
-        pass
 
     def run_model(self, trial: Trial) -> None:
         self.data[trial.index] = run_branin_from_trial(trial)


### PR DESCRIPTION
__main__.py can take command line arguments for python wrapper class, wrapper dir, and other things so that you can pass in a wrapper you wrote in python and it will handle the run script for you. It will also save your scheduler to a json file afterwards as well.

This will work for standard run scripts. Not more exotic run scripts.