### PR TITLE
Update install instructions to include pip from repo

### DIFF
--- a/docs/user_guide/getting_started.rst
+++ b/docs/user_guide/getting_started.rst
@@ -33,7 +33,7 @@ If you don't already have a dedicated conda environment for your model::
      conda create -n boa
      conda activate boa
 
-If you don't need to create a new environment, activate that environment
+If you don't need to create a new environment, activate the existing conda environment you will be using.
 
 If you are not on an x86 mac (or a mac with python running through rosetta), run these commands to install the dependencies::
 

--- a/docs/user_guide/getting_started.rst
+++ b/docs/user_guide/getting_started.rst
@@ -28,14 +28,21 @@ installed. There are two options for this:
 Install boa
 ===========
 
-Create a new environment for boa and activate it::
+If you don't already have a dedicated conda environment for your model::
 
      conda create -n boa
      conda activate boa
 
-Then install dependencies::
+If you don't need to create a new environment, activate that environment
+
+If you are not on an x86 mac (or a mac with python running through rosetta), run these commands to install the dependencies::
 
     conda install botorch -c pytorch -c gpytorch -c conda-forge
+    pip install ax-platform
+
+x86 macs (or a mac with python running through rosetta), run::
+
+    conda install botorch -c pytorch-nightly -c pytorch -c gpytorch -c conda-forge
     pip install ax-platform
 
 Install boa::

--- a/docs/user_guide/getting_started.rst
+++ b/docs/user_guide/getting_started.rst
@@ -28,21 +28,22 @@ installed. There are two options for this:
 Install boa
 ===========
 
-If you need to create a new environment:
+Create a new environment for boa and activate it::
 
      conda create -n boa
      conda activate boa
 
-If you don't need to create a new environment, activate that environment
-Then install dependencies
+Then install dependencies::
 
     conda install botorch -c pytorch -c gpytorch -c conda-forge
     pip install ax-platform
 
-Install BOA
+Install boa::
+
     pip install git+https://github.com/madeline-scyphers/boa.git
 
-Install the develop version of BOA
+If you want to install the latest (bleeding-edge) develop version of boa::
+
     pip install git+https://github.com/madeline-scyphers/boa.git@develop
 
 ********************************

--- a/docs/user_guide/getting_started.rst
+++ b/docs/user_guide/getting_started.rst
@@ -28,6 +28,27 @@ installed. There are two options for this:
 Install boa
 ===========
 
+If you need to create a new environment:
+
+     conda create -n boa
+     conda activate boa
+
+If you don't need to create a new environment, activate that environment
+Then install dependencies
+
+    conda install botorch -c pytorch -c gpytorch -c conda-forge
+    pip install ax-platform
+
+Install BOA
+    pip install git+https://github.com/madeline-scyphers/boa.git
+
+Install the develop version of BOA
+    pip install git+https://github.com/madeline-scyphers/boa.git@develop
+
+********************************
+Installing for Contributing
+********************************
+
 Clone the boa repository from `boa's GitHub page <https://github.com/madeline-scyphers/boa>`_.
 
 If you are not on an x86 mac (or a mac with python running through rosetta), from the root directory of the cloned repository, run::
@@ -44,17 +65,13 @@ x86 macs (or a mac with python running through rosetta), run::
 
 This will install boa in editable mode.
 
-To use install it with pip, run::
-
-    pip install -e .[dev,docs,examples]
-
 ********
 Test run
 ********
 
 Once everything is installed, run the test script to ensure everything is install properly::
 
-    python -m boa.test_scripts.run
+    python -m boa.test_scripts.run_branin
 
 If this test case runs successfully, you can move on to the next steps.
 

--- a/environment_mac_x86.yml
+++ b/environment_mac_x86.yml
@@ -6,10 +6,9 @@ channels:
 - defaults
 dependencies:
 - python=3.9
-- mkl<2022
-- pytorch<1.12.0
-- torchvision
-- torchaudio
+- pytorch-nightly::pytorch
+- pytorch-nightly::torchvision
+- pytorch-nightly::torchaudio
 - numpy
   # 2022/09/25 Pinning because pandas 1.4.3 broke something with ax
   # ax is working on a fix


### PR DESCRIPTION
Update install instructions to first favor installing in a conda env and installing the dependencies and then installing with pip from the GH repo instead of having to clone the repo.