### PR TITLE
Feature/start controller from scheduler json

### DIFF
--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
 
 from boa.ax_instantiation_utils import *  # noqa
 from boa.controller import *  # noqa
+from boa.definitions import PathLike
 from boa.instantiation_base import *  # noqa
 from boa.metrics.metric_funcs import *  # noqa
 from boa.metrics.metrics import *  # noqa

--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -11,7 +11,6 @@ except ImportError:
 
 from boa.ax_instantiation_utils import *  # noqa
 from boa.controller import *  # noqa
-from boa.definitions import PathLike
 from boa.instantiation_base import *  # noqa
 from boa.metrics.metric_funcs import *  # noqa
 from boa.metrics.metrics import *  # noqa

--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import click
 
 from boa.controller import Controller
+from boa.utils import _load_module_from_path, _load_attr_from_module
 from boa.wrappers.wrapper_utils import cd_and_cd_back, load_jsonlike
 
 
@@ -76,17 +77,8 @@ def _main(config_path, rel_to_here, experiment_dir=None):
     sys.path.append(str(rel_path))
     with cd_and_cd_back(working_dir):
         if wrapper_path.exists():
-            # create a module spec from a file location so we can then load that module
-            module_name = "user_wrapper"
-            spec = importlib.util.spec_from_file_location(module_name, wrapper_path)
-            # create that module from that spec from above
-            user_wrapper = importlib.util.module_from_spec(spec)
-            sys.modules[module_name] = user_wrapper
-            # execute the loading and importing of the module
-            spec.loader.exec_module(user_wrapper)
-
-            # since we just loaded the module where the wrapper class is, we can now load it
-            WrapperCls = getattr(user_wrapper, wrapper_name)
+            module = _load_module_from_path(wrapper_path, "user_wrapper")
+            WrapperCls = _load_attr_from_module(module, wrapper_name)
         else:
             from boa.wrappers.script_wrapper import ScriptWrapper as WrapperCls
 

--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -1,11 +1,11 @@
 import sys
 import tempfile
-import time
 from pathlib import Path
 
 import click
 
 from boa.controller import Controller
+from boa.wrappers.script_wrapper import ScriptWrapper
 from boa.wrappers.wrapper_utils import cd_and_cd_back, load_jsonlike
 
 
@@ -60,7 +60,6 @@ def main(config_path, scheduler_path, temporary_dir, rel_to_here):
 
 
 def _main(config_path, scheduler_path, rel_to_here, experiment_dir=None):
-    s = time.time()
     if config_path:
         config_path = Path(config_path).resolve()
     if scheduler_path:
@@ -101,9 +100,7 @@ def _main(config_path, scheduler_path, rel_to_here, experiment_dir=None):
             if wrapper_path.exists():
                 kw = dict(wrapper=wrapper_path, wrapper_name=wrapper_name)
             else:
-                from boa.wrappers.script_wrapper import ScriptWrapper as WrapperCls
-
-                kw = dict(wrapper=WrapperCls)
+                kw = dict(wrapper=ScriptWrapper)
             controller = Controller(
                 config_path=config_path,
                 append_timestamp=append_timestamp,
@@ -112,7 +109,6 @@ def _main(config_path, scheduler_path, rel_to_here, experiment_dir=None):
             )
             controller.initialize_scheduler()
         scheduler = controller.run()
-        print(f"total time = {time.time() - s}")
         return scheduler
 
 

--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -1,4 +1,3 @@
-import importlib.util
 import sys
 import tempfile
 import time
@@ -7,20 +6,26 @@ from pathlib import Path
 import click
 
 from boa.controller import Controller
-from boa.utils import _load_module_from_path, _load_attr_from_module
 from boa.wrappers.wrapper_utils import cd_and_cd_back, load_jsonlike
 
 
 @click.command()
 @click.option(
     "-c",
-    "--config_path",
+    "--config-path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     help="Path to configuration YAML file.",
 )
 @click.option(
+    "-sp",
+    "--scheduler-path",
+    type=click.Path(),
+    default="",
+    help="Path to scheduler json file.",
+)
+@click.option(
     "-td",
-    "--temporary_dir",
+    "--temporary-dir",
     is_flag=True,
     show_default=True,
     default=False,
@@ -31,7 +36,7 @@ from boa.wrappers.wrapper_utils import cd_and_cd_back, load_jsonlike
 )
 @click.option(
     "-rel",
-    "--rel_to_here",
+    "--rel-to-here",
     is_flag=True,
     show_default=True,
     default=False,
@@ -42,26 +47,40 @@ from boa.wrappers.wrapper_utils import cd_and_cd_back, load_jsonlike
     " if you don't pass --rel_to_here then path/to/dir is defined in terms of where your config file is"
     " if you do pass --rel_to_here then path/to/dir is defined in terms of where you launch boa from",
 )
-def main(config_path, temporary_dir, rel_to_here):
+def main(config_path, scheduler_path, temporary_dir, rel_to_here):
+    # config_path = config_path if config_path else None
+    # scheduler_path = scheduler_path if scheduler_path else None
     if temporary_dir:
         with tempfile.TemporaryDirectory() as temp_dir:
             experiment_dir = Path(temp_dir) / "temp"
-            return _main(config_path, rel_to_here, experiment_dir)
-    return _main(config_path, rel_to_here=rel_to_here)
+            return _main(
+                config_path, scheduler_path=scheduler_path, rel_to_here=rel_to_here, experiment_dir=experiment_dir
+            )
+    return _main(config_path, scheduler_path=scheduler_path, rel_to_here=rel_to_here)
 
 
-def _main(config_path, rel_to_here, experiment_dir=None):
+def _main(config_path, scheduler_path, rel_to_here, experiment_dir=None):
     s = time.time()
-    config_path = Path(config_path).resolve()
-    rel_path = config_path.parent
-    if rel_to_here:
-        rel_path = Path.cwd()
+    if config_path:
+        config_path = Path(config_path).resolve()
+    if scheduler_path:
+        scheduler_path = Path(scheduler_path).resolve()
+    if experiment_dir:
+        experiment_dir = Path(experiment_dir).resolve()
 
-    config = load_jsonlike(config_path, normalize=False)
+    if config_path and not rel_to_here:
+        rel_path = config_path.parent
+        config = load_jsonlike(config_path, normalize=False)
+    else:
+        rel_path = Path.cwd()
+        config = {}
 
     script_options = config.get("script_options", {})
     wrapper_name = script_options.get("wrapper_name", "Wrapper")
     append_timestamp = script_options.get("append_timestamp", True)
+
+    scheduler_path = scheduler_path or script_options.get("scheduler_path")
+    scheduler_path = scheduler_path or _prepend_rel_path(rel_path, scheduler_path)
 
     wrapper_path = script_options.get("wrapper_path", "wrapper.py")
     wrapper_path = _prepend_rel_path(rel_path, wrapper_path) if wrapper_path else wrapper_path
@@ -76,20 +95,30 @@ def _main(config_path, rel_to_here, experiment_dir=None):
         sys.path.append(str(working_dir))
     sys.path.append(str(rel_path))
     with cd_and_cd_back(working_dir):
-        if wrapper_path.exists():
-            module = _load_module_from_path(wrapper_path, "user_wrapper")
-            WrapperCls = _load_attr_from_module(module, wrapper_name)
+        if scheduler_path:
+            controller = Controller.from_scheduler_path(scheduler_path=scheduler_path)
         else:
-            from boa.wrappers.script_wrapper import ScriptWrapper as WrapperCls
+            if wrapper_path.exists():
+                kw = dict(wrapper=wrapper_path, wrapper_name=wrapper_name)
+            else:
+                from boa.wrappers.script_wrapper import ScriptWrapper as WrapperCls
 
-        controller = Controller(config_path=config_path, wrapper=WrapperCls)
-        controller.setup(append_timestamp=append_timestamp, experiment_dir=experiment_dir)
+                kw = dict(wrapper=WrapperCls)
+            controller = Controller(
+                config_path=config_path,
+                append_timestamp=append_timestamp,
+                experiment_dir=experiment_dir,
+                **kw,
+            )
+            controller.initialize_scheduler()
         scheduler = controller.run()
         print(f"total time = {time.time() - s}")
         return scheduler
 
 
 def _prepend_rel_path(rel_path, path):
+    if not path:
+        return path
     path = Path(path)
     if not path.is_absolute():
         path = rel_path / path

--- a/boa/ax_instantiation_utils.py
+++ b/boa/ax_instantiation_utils.py
@@ -37,11 +37,11 @@ def instantiate_search_space_from_json(
     return BoaInstantiationBase.make_search_space(parameters, parameter_constraints)
 
 
-def get_generation_strategy(config: dict, experiment: Experiment = None):
+def get_generation_strategy(config: dict, experiment: Experiment = None, **kwargs):
     if config.get("steps"):  # if they are explicitly defining the steps, use those to make gen strat
         return generation_strategy_from_config(config=config, experiment=experiment)
     # else auto generate the gen strat
-    return choose_generation_strategy_from_experiment(experiment=experiment, config=config)
+    return choose_generation_strategy_from_experiment(experiment=experiment, config=config, **kwargs)
 
 
 def generation_strategy_from_config(config: dict, experiment: Experiment = None):
@@ -59,12 +59,12 @@ def generation_strategy_from_config(config: dict, experiment: Experiment = None)
     return gs
 
 
-def choose_generation_strategy_from_experiment(experiment: Experiment, config: dict) -> GenerationStrategy:
+def choose_generation_strategy_from_experiment(experiment: Experiment, config: dict, **kwargs) -> GenerationStrategy:
     return choose_generation_strategy(
         search_space=experiment.search_space,
         experiment=experiment,
         optimization_config=experiment.optimization_config,
-        **get_dictionary_from_callable(choose_generation_strategy, config),
+        **{**get_dictionary_from_callable(choose_generation_strategy, config), **kwargs},
     )
 
 
@@ -73,6 +73,7 @@ def get_scheduler(
     generation_strategy: GenerationStrategy = None,
     scheduler_options: SchedulerOptions = None,
     config: dict = None,
+    **kwargs,
 ) -> Scheduler:
     scheduler_options = scheduler_options or SchedulerOptions(**config["optimization_options"]["scheduler"])
     if generation_strategy is None:
@@ -106,11 +107,7 @@ def get_scheduler(
     )
 
 
-def get_experiment(
-    config: dict,
-    runner: Runner,
-    wrapper: BaseWrapper = None,
-):
+def get_experiment(config: dict, runner: Runner, wrapper: BaseWrapper = None, **kwargs):
     opt_options = config["optimization_options"]
 
     search_space = instantiate_search_space_from_json(config.get("parameters"), config.get("parameter_constraints"))

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -142,10 +142,5 @@ class Controller:
         try:
             scheduler.run_all_trials()
         finally:
-            self.logger.info("\nTrials completed! Total run time: %d", time.time() - start)
-        # try:
-        #     experiment_dir = wrapper.experiment_dir
-        #     scheduler_to_json_file(scheduler, experiment_dir / "scheduler.json")
-        # except Exception as e:
-        #     self.logger.exception("failed to save scheduler to json! Reason: %s" % repr(e))
+            self.logger.info("Trials completed! Total run time: %d", time.time() - start)
         return scheduler

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -24,6 +24,13 @@ from boa.storage import scheduler_from_json_file
 from boa.wrappers.base_wrapper import BaseWrapper
 from boa.wrappers.wrapper_utils import get_dt_now_as_str, initialize_wrapper
 
+HEADER_BAR = """
+##############################################
+"""
+LOG_INFO = """BOA Experiment Run
+Output Experiment Dir: {exp_dir}
+Start Time {start_time}"""
+
 
 class Controller:
     """
@@ -132,7 +139,12 @@ class Controller:
         experiment has been stopped for another reason.
         """
         start = time.time()
-        self.logger.info("Start time: %s", get_dt_now_as_str())
+        start_tm = get_dt_now_as_str()
+        self.logger.info(
+            f"\n{HEADER_BAR}"
+            f"\n\n{LOG_INFO.format(exp_dir=self.wrapper.experiment_dir, start_time=start_tm)}"
+            f"\n{HEADER_BAR}"
+        )
 
         scheduler = scheduler or self.scheduler
         wrapper = wrapper or self.wrapper
@@ -140,7 +152,18 @@ class Controller:
             raise ValueError("Scheduler and wrapper must be defined, or setup in setup method!")
 
         try:
+            final_msg = "Trials Completed!"
             scheduler.run_all_trials()
+        except BaseException as e:
+            final_msg = f"Error Completing because of {repr(e)}"
+            raise
         finally:
-            self.logger.info("Trials completed! Total run time: %d", time.time() - start)
+            self.logger.info(
+                f"\n{HEADER_BAR}"
+                f"\n{final_msg}"
+                f"\n{LOG_INFO.format(exp_dir=self.wrapper.experiment_dir, start_time=start_tm)}"
+                f"\nEnd Time: {get_dt_now_as_str()}"
+                f"\nTotal Run Time: {time.time() - start}"
+                f"\n{HEADER_BAR}"
+            )
         return scheduler

--- a/boa/definitions.py
+++ b/boa/definitions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 
@@ -5,3 +7,5 @@ ROOT = Path(__file__).resolve().parent.parent
 
 TEST_SCRIPTS_DIR = Path(__file__).resolve().parent / "scripts"
 IS_WINDOWS = os.name == "nt"
+
+PathLike = str | os.PathLike

--- a/boa/definitions.py
+++ b/boa/definitions.py
@@ -1,11 +1,18 @@
-from __future__ import annotations
+"""
+###################################
+Definitions
+###################################
+
+"""
 
 import os
 from pathlib import Path
+from typing import TypeVar
 
 ROOT = Path(__file__).resolve().parent.parent
 
 TEST_SCRIPTS_DIR = Path(__file__).resolve().parent / "scripts"
 IS_WINDOWS = os.name == "nt"
 
-PathLike = str | os.PathLike
+PathLike = TypeVar("PathLike", str, os.PathLike)
+PathLike_tup = (str, os.PathLike)

--- a/boa/definitions.py
+++ b/boa/definitions.py
@@ -1,10 +1,3 @@
-"""
-###################################
-Definitions
-###################################
-
-"""
-
 import os
 from pathlib import Path
 from typing import TypeVar

--- a/boa/logger.py
+++ b/boa/logger.py
@@ -1,6 +1,6 @@
 import logging
 
-DEFAULT_LOG_LEVEL: int = logging.WARNING
+DEFAULT_LOG_LEVEL: int = logging.INFO
 
 
 def get_logger(name: str, level: int = DEFAULT_LOG_LEVEL) -> logging.Logger:
@@ -23,17 +23,37 @@ def get_logger(name: str, level: int = DEFAULT_LOG_LEVEL) -> logging.Logger:
     logger = logging.getLogger(name)
     logger.setLevel(level)
 
-    ch = logging.StreamHandler()
-    ch.setLevel(level)
+    stream_handle: logging.StreamHandler = build_stream_handler()
+    logger.addHandler(stream_handle)
+
+    # ch = logging.StreamHandler()
+    # ch.setLevel(level)
     # create formatter and add it to the handlers
-    formatter = get_formatter()
-    ch.setFormatter(formatter)
+    # formatter = get_formatter()
+    # ch.setFormatter(formatter)
     # add the handlers to the logger
-    logger.addHandler(ch)
+    # logger.addHandler(ch)
     return logger
 
 
 def get_formatter():
-    fmt = "[%(levelname)s %(asctime)s] %(output_name)s %(processName)s %(threadName)s: %(message)s"
+    fmt = "[%(levelname)s %(asctime)s %(processName)s] %(name)s: %(message)s"
     formatter = logging.Formatter(fmt=fmt)
     return formatter
+
+
+def build_stream_handler(level: int = DEFAULT_LOG_LEVEL) -> logging.StreamHandler:
+    """Build the default stream handler used for most Ax logging. Sets
+    default level to INFO, instead of WARNING.
+
+    Args:
+        level: The log level. By default, sets level to INFO
+
+    Returns:
+        A logging.StreamHandler instance
+    """
+    console = logging.StreamHandler()
+    console.setLevel(level=level)
+    formatter = get_formatter()
+    console.setFormatter(formatter)
+    return console

--- a/boa/logger.py
+++ b/boa/logger.py
@@ -26,13 +26,6 @@ def get_logger(name: str, level: int = DEFAULT_LOG_LEVEL) -> logging.Logger:
     stream_handle: logging.StreamHandler = build_stream_handler()
     logger.addHandler(stream_handle)
 
-    # ch = logging.StreamHandler()
-    # ch.setLevel(level)
-    # create formatter and add it to the handlers
-    # formatter = get_formatter()
-    # ch.setFormatter(formatter)
-    # add the handlers to the logger
-    # logger.addHandler(ch)
     return logger
 
 
@@ -43,7 +36,7 @@ def get_formatter():
 
 
 def build_stream_handler(level: int = DEFAULT_LOG_LEVEL) -> logging.StreamHandler:
-    """Build the default stream handler used for most Ax logging. Sets
+    """Build the default stream handler used for most BOA logging. Sets
     default level to INFO, instead of WARNING.
 
     Args:

--- a/boa/metaclasses.py
+++ b/boa/metaclasses.py
@@ -9,8 +9,10 @@ to make sure that if users do any directory changes inside a wrapper function,
 the original directory is returned to afterwards.
 
 """
+import sys
 from abc import ABCMeta
 from functools import wraps
+from pathlib import Path
 
 from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
 from ax.storage.metric_registry import CORE_METRIC_REGISTRY
@@ -37,8 +39,6 @@ def write_exception_to_log(func):
 
 class WrapperRegister(ABCMeta):
     def __init__(cls, *args, **kwargs):
-        # CORE_ENCODER_REGISTRY[cls] = cls.wrapper_to_dict
-        # CORE_DECODER_REGISTRY[cls.__name__] = cls
         _add_common_encodes_and_decodes()
         cls.load_config = write_exception_to_log(cd_and_cd_back_dec()(cls.load_config))
         cls.mk_experiment_dir = write_exception_to_log(cd_and_cd_back_dec()(cls.mk_experiment_dir))
@@ -47,6 +47,7 @@ class WrapperRegister(ABCMeta):
         cls.set_trial_status = write_exception_to_log(cd_and_cd_back_dec()(cls.set_trial_status))
         cls.fetch_trial_data = write_exception_to_log(cd_and_cd_back_dec()(cls.fetch_trial_data))
         cls._fetch_trial_data = write_exception_to_log(cd_and_cd_back_dec()(cls._fetch_trial_data))
+        cls._path = Path(sys.modules[cls.__module__].__file__)
         super().__init__(*args, **kwargs)
 
 

--- a/boa/scheduler.py
+++ b/boa/scheduler.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import logging
-import os
 from pprint import pformat
 from typing import Iterable, Optional
 
 from ax.core.optimization_config import OptimizationConfig
 from ax.service.scheduler import Scheduler as AxScheduler
 
+from boa.definitions import PathLike
 from boa.runner import WrappedJobRunner
 from boa.storage import scheduler_to_json_file
 
@@ -126,7 +126,7 @@ class Scheduler(AxScheduler):
                 trials = {int(best_trial): dict(params=best_params, means=means_dict, cov_matrix=cov_matrix)}
         return trials
 
-    def save_to_json(self, filepath: os.PathLike | str = None):
+    def save_to_json(self, filepath: PathLike = None):
         """Save Scheduler to json file. Defaults to `wrapper.experiment_dir` / `filepath`"""
         filepath = filepath or "scheduler.json"
         try:

--- a/boa/scripts/synth_func_cli.py
+++ b/boa/scripts/synth_func_cli.py
@@ -5,6 +5,9 @@ import click
 import numpy as np
 
 import boa
+from boa.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 @click.command()
@@ -37,7 +40,6 @@ def main(output_dir: Path, input_size, standard_dev, xs):
     results = dict(input=X.tolist(), output=synthetic_func(X).tolist(), metric_name="branin")
     with open(output_dir / "output.json", "w") as outfile:
         json.dump(results, outfile, indent=4)
-    print(f"saved results: {results} to {output_dir / 'output.json'}")
 
 
 if __name__ == "__main__":

--- a/boa/scripts/synth_func_config.yaml
+++ b/boa/scripts/synth_func_config.yaml
@@ -14,6 +14,7 @@ optimization_options:
         total_trials: 20
     experiment:
         name: "test_experiment"
+    on_reload:
 
 parameters:
     x0:
@@ -27,3 +28,8 @@ parameters:
 
 model_options:
     input_size: 15
+
+script_options:
+    wrapper_path: ./script_wrappers.py
+    wrapper_name: Wrapper
+    append_timestamp: True

--- a/boa/storage.py
+++ b/boa/storage.py
@@ -58,9 +58,6 @@ def scheduler_from_json_file(filepath: PathLike = "scheduler.json", wrapper=None
         wrapper.working_dir = wrapper_dict.get("working_dir")
         wrapper.metric_names = wrapper_dict.get("metric_names")
 
-    if "config" in kwargs:
-        wrapper
-
     for trial in scheduler.running_trials:
         wrapper.set_trial_status(trial)  # try and complete or fail and leftover trials
 

--- a/boa/storage.py
+++ b/boa/storage.py
@@ -42,7 +42,7 @@ def scheduler_to_json_file(scheduler, filepath: os.PathLike = "scheduler_snapsho
 
 
 def scheduler_from_json_file(filepath: os.PathLike = "scheduler.json", wrapper=None, **kwargs) -> Scheduler:
-    """Restore an `AxClient` and its state from a JSON-serialized snapshot,
+    """Restore an `Scheduler` and its state from a JSON-serialized snapshot,
     residing in a .json file by the given path.
     """
     with open(filepath, "r") as file:  # pragma: no cover

--- a/boa/storage.py
+++ b/boa/storage.py
@@ -40,7 +40,6 @@ def scheduler_to_json_file(scheduler, filepath: PathLike = "scheduler_snapshot.j
     with open(filepath, "w+") as file:  # pragma: no cover
         file.write(json.dumps(scheduler_to_json_snapshot(scheduler)))
         logger.info(f"Saved JSON-serialized state of optimization to `{filepath}`.")
-        print(f"Saved JSON-serialized state of optimization to `{filepath}`.")
 
 
 def scheduler_from_json_file(filepath: PathLike = "scheduler.json", wrapper=None, **kwargs) -> Scheduler:

--- a/boa/utils.py
+++ b/boa/utils.py
@@ -10,8 +10,13 @@ getting the signature matching
 
 from __future__ import annotations
 
+import importlib
 import inspect
+import os
+import sys
+import types
 from collections.abc import Iterable, Mapping
+from types import ModuleType
 from typing import Any, Callable, Optional, Type
 
 
@@ -59,6 +64,23 @@ def serialize_init_args(class_, *, parents: list[Type] = None, match_private: bo
     args = vars(class_)  # TODO don't use vars? maybe?
     return extract_init_args(args, class_=class_, parents=parents, match_private=match_private, **kwargs)
 
+
+def _load_module_from_path(module_path: os.PathLike | str, module_name: str = "foo") -> types.ModuleType:
+    """Load a module dynamically from a path"""
+    # create a module spec from a file location, so we can then load that module
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    # create that module from that spec from above
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    # execute the loading and importing of the module
+    spec.loader.exec_module(module)
+
+    # return loaded module
+    return module
+
+
+def _load_attr_from_module(module: ModuleType, to_load: str) -> Type | Callable | Any:
+    return getattr(module, to_load)
 
 def extract_init_args(
     args: dict[str, Any], class_: Type, *, parents: list[Type] = None, match_private: bool = False, **kwargs

--- a/boa/utils.py
+++ b/boa/utils.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 
 import importlib
 import inspect
-import os
 import sys
 import types
 from collections.abc import Iterable, Mapping
 from types import ModuleType
 from typing import Any, Callable, Optional, Type
+
+from boa.definitions import PathLike
 
 
 def get_callable_signature(callable: Callable) -> inspect.Signature:
@@ -65,7 +66,7 @@ def serialize_init_args(class_, *, parents: list[Type] = None, match_private: bo
     return extract_init_args(args, class_=class_, parents=parents, match_private=match_private, **kwargs)
 
 
-def _load_module_from_path(module_path: os.PathLike | str, module_name: str = "foo") -> types.ModuleType:
+def _load_module_from_path(module_path: PathLike, module_name: str = "foo") -> types.ModuleType:
     """Load a module dynamically from a path"""
     # create a module spec from a file location, so we can then load that module
     spec = importlib.util.spec_from_file_location(module_name, module_path)
@@ -81,6 +82,7 @@ def _load_module_from_path(module_path: os.PathLike | str, module_name: str = "f
 
 def _load_attr_from_module(module: ModuleType, to_load: str) -> Type | Callable | Any:
     return getattr(module, to_load)
+
 
 def extract_init_args(
     args: dict[str, Any], class_: Type, *, parents: list[Type] = None, match_private: bool = False, **kwargs

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -307,7 +307,7 @@ class BaseWrapper(metaclass=WrapperRegister):
         self._metric_cache[trial.index].update(res)
 
         for metric_name in self._metric_cache[trial.index].keys():
-            if metric_name not in self.metric_names:
+            if self.metric_names and metric_name not in self.metric_names:
                 logger.warning(
                     f"found extra returned metric: {metric_name}" f" in returned metrics from fetch_trial_data"
                 )

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -427,7 +427,7 @@ class BaseWrapper(metaclass=WrapperRegister):
         """
 
     def to_dict(self) -> dict:
-        """Convert runner to a dictionary."""
+        """Convert BaseWrapper to a dictionary."""
 
         properties = object_to_json(
             dict(

--- a/boa/wrappers/wrapper_utils.py
+++ b/boa/wrappers/wrapper_utils.py
@@ -481,6 +481,7 @@ def make_experiment_dir(
     experiment_name: str = "",
     append_timestamp: bool = True,
     exist_ok: bool = False,
+    **kwargs,
 ):
     """
     Creates directory for the experiment and returns the path.

--- a/boa/wrappers/wrapper_utils.py
+++ b/boa/wrappers/wrapper_utils.py
@@ -593,10 +593,9 @@ def make_trial_dir(experiment_dir: PathLike, trial_index: int, exist_ok=True, **
     pathlib.Path
         Directory for the trial
     """
-    print(experiment_dir)
     trial_dir = get_trial_dir(experiment_dir, trial_index, **kwargs)
-    print(trial_dir)
     trial_dir.mkdir(exist_ok=exist_ok)
+    logger.info(f"Trial directory made: {trial_dir}")
     return trial_dir
 
 

--- a/docs/code_reference.rst
+++ b/docs/code_reference.rst
@@ -24,7 +24,6 @@ This is where you will find information about :doc:`BOA's </index>` Wrapper clas
     boa.wrappers.script_wrapper
     boa.wrappers.wrapper_utils
 
-
 :doc:`Metrics <api/boa.metrics>`:
 =================================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,8 +69,7 @@ nitpick_ignore_regex = [
     (r".*", r".*ax.*"),
     (r".*", r".*botorch.*"),
     (r".*", r"array.*like"),
-    ("py:class", ".*PathLike")  # TODO, why can't we use type aliases?
-
+    ("py:class", ".*PathLike"),  # TODO, why can't we use type aliases?
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,6 @@ project = "boa"
 copyright = "2022, Madeline Scyphers, Justine Missik"
 author = "Madeline Scyphers, Justine Missik"
 
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -63,12 +62,15 @@ nitpick_ignore = [
     ("py:class", "Objective"),
     ("py:class", "BaseTrial"),
     ("py:class", "DBSettings"),
+    # ("py:class", "PathLike"),  # TODO, why can't we use type aliases?
 ]
 
 nitpick_ignore_regex = [
     (r".*", r".*ax.*"),
     (r".*", r".*botorch.*"),
     (r".*", r"array.*like"),
+    ("py:class", ".*PathLike")  # TODO, why can't we use type aliases?
+
 ]
 
 
@@ -93,6 +95,10 @@ autoclass_content = "both"  # Add __init__ doc (ie. params) to class summaries
 autodoc_inherit_docstrings = True  # If no docstring, inherit from base class
 autodoc_member_order = "bysource"
 autodoc_typehints = "both"
+
+# autodoc_type_aliases = {
+#     "PathLike": "boa.definitions.PathLike"
+# }
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/user_guide/package_overview.rst
+++ b/docs/user_guide/package_overview.rst
@@ -57,17 +57,26 @@ Starting From Command Line
 If you are using :doc:`BOA's </index>` in built :mod:`.controller` for your run script,
 you can start your run easily from the command line.
 
-With your conda environment for boa activated, run:
+With your conda environment for boa activated, run::
 
     python -m boa --config_path path/to/your/config/file
 
-For a list of options and descriptions, type:
+or::
+
+    python -m boa -c path/to/your/config/file
+
+:doc:`BOA's </index>` will save the its current state automatically to a `scheduler.json` file in your output experiment directory every 1-few trials (depending on parallelism settings). The console will output the Output directory at the start and end of your runs to the console, it will also throughout the run, whenever it saves the `scheduler.json` file, output to the console the location where the file is being saved. You can resume a stopped run from a scheduler file::
+
+    python -m boa --scheduler-path path/to/your/scheduler.json
+
+or::
+
+    python -m boa -sp path/to/your/scheduler.json
+
+
+For a list of options and descriptions, type::
 
     python -m boa --help
-
-
-.. todo::
-    Add more information here when other language feature is fully merged in
 
 A fuller example using the command line interface can be found  :doc:`here </examples/example_py_run>`
 

--- a/docs/user_guide/package_overview.rst
+++ b/docs/user_guide/package_overview.rst
@@ -43,7 +43,7 @@ Creating a run script (sometimes needed)
 Most of the time you won't need to write a run script because BOA has an built-in run script in
 its :mod:`.controller`. But if you do need more control over your run script than the default
 provides, you can either subclass :class:`.Controller` or write your own run script. Subclassing
-:class:`.Controller` might be easier if you just need to modify :meth:`.Controller.run` or :meth:`.Controller.setup`
+:class:`.Controller` might be easier if you just need to modify :meth:`.Controller.run` or :meth:`.Controller.initialize_wrapper` or :meth:`.Controller.initialize_scheduler`
 but can utilize the rest of the functions. If you need a lot of customization, writing your own run script might be
 easier. Some Custom run scripts are included in the link below.
 

--- a/docs/user_guide/run_script.rst
+++ b/docs/user_guide/run_script.rst
@@ -22,4 +22,3 @@ link to source: https://github.com/jemissik/fetch3_nhl/blob/develop/fetch3/optim
     :language: python
 
 link to source: https://github.com/madeline-scyphers/palm_wrapper/blob/main/palm_wrapper/optimize/run.py
-

--- a/environment_dev_update.yml
+++ b/environment_dev_update.yml
@@ -5,12 +5,12 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-  - pytest
   - myst-nb
   - jupyter
   - pip
   - pip:
     # we use external role, which is from v4.4. in conda this causes conflicts
+    - pytest
     - pytest-cov
     - invoke
     - isort

--- a/tasks.py
+++ b/tasks.py
@@ -114,7 +114,7 @@ def all(
     if not command.config.run.warn:
         print(
             """
-All Style Checks Tests Passed Successfully
+All Checks Passed Successfully
 ==========================================
 """
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def stand_alone_opt_package_run(request, tmp_path_factory, cd_to_root_and_back_s
     else:
         config_path = TEST_DIR / "scripts/stand_alone_opt_package/stand_alone_pkg_config.yaml"
 
-    yield dunder_main.main(split_shell_command(f"--config_path {config_path} -td"), standalone_mode=False)
+    yield dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)
 
 
 @pytest.fixture(scope="session")
@@ -116,4 +116,4 @@ def r_scripts_run(request, tmp_path_factory, cd_to_root_and_back_session):
     full_or_light = request.param
     config_path = TEST_DIR / f"scripts/other_langs/r_package_{full_or_light}/config.yaml"
 
-    yield dunder_main.main(split_shell_command(f"--config_path {config_path} -td"), standalone_mode=False)
+    yield dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)

--- a/tests/unit_tests/test_metrics.py
+++ b/tests/unit_tests/test_metrics.py
@@ -1,7 +1,6 @@
 import tempfile
 
 import numpy as np
-import pytest
 
 from boa import (
     BaseWrapper,
@@ -74,8 +73,8 @@ def test_load_metric_from_config(synth_config, metric_config):
 
 
 def test_metric_fetch_trial_data_works_with_wrapper_fetch_trial_data_and_test_sem_passing(moo_config, tmp_path):
-    controller = Controller(config=moo_config, wrapper=Wrapper)
-    controller.setup(experiment_dir=tmp_path)
+    controller = Controller(config=moo_config, wrapper=Wrapper, experiment_dir=tmp_path)
+    controller.initialize_scheduler()
 
     scheduler = controller.scheduler
     experiment = controller.experiment
@@ -103,8 +102,8 @@ def test_metric_fetch_trial_data_works_with_wrapper_fetch_trial_all_data_and_tes
 ):
     orig_metrics = moo_config["optimization_options"]["objective_options"]["objectives"]
     moo_config["optimization_options"]["objective_options"]["objectives"] = orig_metrics[:1]
-    controller = Controller(config=moo_config, wrapper=Wrapper)
-    controller.setup(experiment_dir=tmp_path)
+    controller = Controller(config=moo_config, wrapper=Wrapper, experiment_dir=tmp_path)
+    controller.initialize_scheduler()
 
     scheduler = controller.scheduler
     experiment = controller.experiment
@@ -117,8 +116,8 @@ def test_metric_fetch_trial_data_works_with_wrapper_fetch_trial_all_data_and_tes
 
 
 def test_metric_fetch_trial_data_works_with_wrapper_fetch_trial_data_single_and_test_sem_passing(moo_config, tmp_path):
-    controller = Controller(config=moo_config, wrapper=Wrapper)
-    controller.setup(fetch_all=False, experiment_dir=tmp_path)
+    controller = Controller(config=moo_config, wrapper=Wrapper, fetch_all=False, experiment_dir=tmp_path)
+    controller.initialize_scheduler()
 
     scheduler = controller.scheduler
     experiment = controller.experiment


### PR DESCRIPTION
- [Controller and __main__ can be passed scheduler.json to resume run](https://github.com/madeline-scyphers/boa/commit/fb917f6498887a5673a0cdc53a31c9f04abcc34d)
  Controller and __main__ can be passed a scheduler.json file and they will resume experiment run if the experiment was stopped.
  If some of the trials of the exp were mid run when the run was stopped, then 1 attempt will be made to compelte them
  and then they are all marked failed since if the trial run was actually just ended too, it oculd lead to the exp just hanging.
  Just ending it will allow Ax to start new trials in their place instead.
- [Update docs to give more information about scheduler saving and reloading](https://github.com/madeline-scyphers/boa/pull/44/commits/1717d87c7035bea691915088076f348ebc37fafc)