### PR TITLE
Add info only metrics

### DIFF
--- a/boa/ax_instantiation_utils.py
+++ b/boa/ax_instantiation_utils.py
@@ -112,6 +112,10 @@ def get_experiment(config: dict, runner: Runner, wrapper: BaseWrapper = None, **
 
     search_space = instantiate_search_space_from_json(config.get("parameters"), config.get("parameter_constraints"))
 
+    info_only_metrics = BoaInstantiationBase.get_metrics_from_obj_config(
+        **opt_options["objective_options"], info_only=True
+    )
+
     optimization_config = BoaInstantiationBase.make_optimization_config(
         **get_dictionary_from_callable(BoaInstantiationBase.make_optimization_config, opt_options["objective_options"]),
         wrapper=wrapper,
@@ -127,6 +131,7 @@ def get_experiment(config: dict, runner: Runner, wrapper: BaseWrapper = None, **
         search_space=search_space,
         optimization_config=optimization_config,
         runner=runner,
+        tracking_metrics=info_only_metrics,
         **get_dictionary_from_callable(Experiment.__init__, opt_options["experiment"]),
     )
     # we use getattr here in case someone subclassed without the proper super calls

--- a/boa/instantiation_base.py
+++ b/boa/instantiation_base.py
@@ -35,11 +35,18 @@ class BoaInstantiationBase(InstantiationBase):
         return metric
 
     @classmethod
-    def get_metrics_from_obj_config(cls, objectives, **kwargs):
+    def get_metrics_from_obj_config(cls, objectives, info_only=False, **kwargs):
+        """"""
         metrics = []
         for metric_opts in objectives:
+            tracker = metric_opts.get("info_only", False)
             metric = cls.get_metric_from_obj_config(metric_opts, **kwargs)
-            metrics.append(metric)
+            if info_only is None:  # get all metrics
+                metrics.append(metric)
+            elif info_only is True and tracker:  # only get tracking metrics
+                metrics.append(metric)
+            elif info_only is False and not tracker:  # only get not tracking metrics
+                metrics.append(metric)
         return metrics
 
     @classmethod

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -94,9 +94,9 @@ class BaseWrapper(metaclass=WrapperRegister):
     def config(self, config):
         self._config = config or {}
         if self._config:
-            self.ex_settings = self.config["optimization_options"]
-            self.model_settings = self.config.get("model_options", {})
-            self.script_options = self.config.get("script_options", {})
+            self.ex_settings = self._config["optimization_options"]
+            self.model_settings = self._config.get("model_options", {}) or {}
+            self.script_options = self._config.get("script_options", {}) or {}
             metric_propertis = {}
             for metric in self.ex_settings["objective_options"]["objectives"]:
                 if "properties" in metric:

--- a/tests/test_configs/test_config_metric.yaml
+++ b/tests/test_configs/test_config_metric.yaml
@@ -11,6 +11,11 @@ optimization_options:
             # only list 1 metric for a single objective optimization
             - name: rmse
               metric: RootMeanSquaredError
+            # We can mark metrics as info only just so we can track their results later
+            # without it impacting our optimization
+            - name: Meanyyy
+              metric: Mean
+              info_only: True
         # List all outcome constraints here
         outcome_constraints: []
     # Here we explicitly define a generation strategy

--- a/tests/test_configs/test_config_moo.yaml
+++ b/tests/test_configs/test_config_moo.yaml
@@ -4,7 +4,7 @@ optimization_options:
         objectives:
             # List all of your metrics here,
             # only list multiple objectives for a multi objective optimization
-            - metric: RMSE
+            - metric: RMSE  # names default to the metric itself if not specified
             - name: Meanyyy
               metric: Mean
         outcome_constraints: []


### PR DESCRIPTION
Add ability to specify a metric as info only
by marking it in the metric options as info_only: True 
It will still be calculated, but won't be used for any optimization.