### PR TITLE
Bugfix: pin sqlalchemy

### DIFF
--- a/docs/user_guide/getting_started.rst
+++ b/docs/user_guide/getting_started.rst
@@ -38,14 +38,13 @@ If you don't need to create a new environment, activate the existing conda envir
 
 If you are not on an x86 mac (or a mac with python running through rosetta), run these commands to install the dependencies::
 
-    conda install botorch -c pytorch -c gpytorch -c conda-forge
-    pip install ax-platform
+    conda install botorch torchvision "sqlalchemy<2.0" "ax-platform==0.2.9" -c pytorch -c gpytorch -c conda-forge
 
 x86 macs (or a mac with python running through rosetta), run::
 
     conda install pytorch<1.12.0 -c pytorch
     conda install botorch -c pytorch -c gpytorch -c conda-forge
-    pip install ax-platform
+    pip install ax-platform "sqlalchemy<2.0"
 
 Install boa::
 

--- a/docs/user_guide/package_overview.rst
+++ b/docs/user_guide/package_overview.rst
@@ -59,7 +59,7 @@ you can start your run easily from the command line.
 
 With your conda environment for boa activated, run::
 
-    python -m boa --config_path path/to/your/config/file
+    python -m boa --config-path path/to/your/config/file
 
 or::
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - scipy
 - scikit-learn
 - click
-- sqlalchemy
+- sqlalchemy<2.0  # Ax breaks with sqlalchemy>2.0
 - plotly>=5.10.0
 - notebook>=5.3
 - ipywidgets>=7.5

--- a/environment_mac_x86.yml
+++ b/environment_mac_x86.yml
@@ -16,7 +16,7 @@ dependencies:
 - scipy
 - scikit-learn
 - click
-- sqlalchemy
+- sqlalchemy<2.0  # Ax breaks with sqlalchemy>2.0
 - plotly
 - notebook
 - ipywidgets


### PR DESCRIPTION
- Pin sqlalchemy<2.0 in environment files 
- Update user install instructions to make sure sqlalchemy<2.0 is installed for the non-dev install 
- Fix typo in launch instructions 

Closes #65 
Closes #64 