### PR TITLE
Add information and example of language agnostic interface

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -69,7 +69,6 @@ The main administration group currently consists of:
 - Justine Missik
 
 ## Attribution
-## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.1, available at

--- a/boa/wrappers/__init__.py
+++ b/boa/wrappers/__init__.py
@@ -43,13 +43,13 @@ to the following sections
 ..  code-block:: YAML
 
     script_options:
-        # only include `write_configs` if you are using a `Write Configs Script`
-        write_configs: whatever your write_configs run command is
+        write_configs: whatever your write_configs run command is  # only include `write_configs` if you are using a `Write Configs Script`
         run_model: whatever your run_model run command is
-        # only include `set_trial_status` if you are using a `Set Trial Status Script`
-        set_trial_status: whatever your set_trial_status run command is
-        # only include `fetch_trial_data` if you are using a `Fetch Trial Data Script`
-        fetch_trial_data: whatever your fetch_trial_data run command is
+        set_trial_status: whatever your set_trial_status run command is  # only include `set_trial_status` if you are using a `Set Trial Status Script`
+        fetch_trial_data: whatever your fetch_trial_data run command is  # only include `fetch_trial_data` if you are using a `Fetch Trial Data Script`
+
+For examples on the formatting of the json files you will output back to BOA, see :meth:`.ScriptWrapper.fetch_trial_data`
+and :meth:`.ScriptWrapper.set_trial_status`
 
 Here is an example of a `Run Model Script` that handles setting the trial status and outputting
 the data back to BOA as well. So this script is all that is needed (other than the model itself,
@@ -57,6 +57,29 @@ which in this case is a synthetic function called hartman6, but that is just a s
 black box model call).
 
 .. literalinclude:: ../../tests/scripts/other_langs/r_package_streamlined/run_model.R
+    :language: R
+
+You can also partition the logic of your code into different steps if that is more appropriate for you project.
+Below is an example that does that
+
+First we see the `Write Configs Script`
+
+.. literalinclude:: ../../tests/scripts/other_langs/r_package_full/write_configs.R
+    :language: R
+
+Then the `Run Model Script`
+
+.. literalinclude:: ../../tests/scripts/other_langs/r_package_full/run_model.R
+    :language: R
+
+Then the `Set Trial Status Script`
+
+.. literalinclude:: ../../tests/scripts/other_langs/r_package_full/set_trial_status.R
+    :language: R
+
+Finally, the `Fetch Trial Status Script`
+
+.. literalinclude:: ../../tests/scripts/other_langs/r_package_full/fetch_trial_data.R
     :language: R
 
 -------------------------
@@ -100,7 +123,7 @@ FETCH3's wrapper provides a simple example of this function for a case where the
 be written to a yaml file:
 
 .. rli:: https://raw.githubusercontent.com/jemissik/fetch3_nhl/develop/fetch3/optimize/fetch_wrapper.py
-   :pyobject: write_configs
+   :pyobject: Fetch3Wrapper.write_configs
 
 The palm_wrapper used to wrap PALM provides an example of a model with more complicated configuration requirements.
 Here, the parameters are written to a YAML file, but then a batch job script must also be written for each

--- a/boa/wrappers/__init__.py
+++ b/boa/wrappers/__init__.py
@@ -3,7 +3,63 @@
 Creating model wrappers
 ########################
 
-To create a model wrapper, you will create a child class of boa's :class:`.BaseWrapper`
+---------------------------
+Language Agnostic Interface
+---------------------------
+
+The language agnostic interface revolves around you writing 1 or more script(s) (detailed below)
+and :doc:`BOA </index>` passing a command line argument to this 1 or more script(s) which
+is the path to a folder with json files that contain optimization information, such as the
+parameters for a trial.
+
+You have a few options on the number of scripts to write. The options are listed below:
+
+* Write Configs: this script is supposed to let you write out any configurations or setup stuff
+  your model may need to run. It is called right before the `Run Model Script` to let you do
+  set up stuff.
+  (This script is optional, and much or all of this can be accomplished in your
+  Run Model script, but is provided to allow code partitioning options)
+* Run Model: This is the script that actually runs your model codel. This can be directly in
+  this script, or maybe this script kicks off another script that is your model. For example
+  maybe this script is your model script, but maybe you write a convenience wrapper in R to
+  interface with a Fortran model, this could kick off your R interface code.
+* Set Trial Status: This script writes out to BOA if your trial passed or failed.
+  (This script is optional, and much or all of this can be accomplished in your
+  `Run Model Script` or your `Fetch Trial Data Script`, but is provided to allow code
+  partitioning options)
+* Fetch Trial Data: This script writes out your data for BOA to consume.
+  (This script is optional, and much or all of this can be accomplished in your
+  `Run Model Script`, but is provided to allow code partitioning options)
+
+To run any of these scripts, in your config file, you will add command line run commands
+(as in what you would type in your terminal (bash, zsh, powershell, windows command prompt, etc.)
+to start your script. This might be something like `Rscript run_model.R` or `python run_model.py`).
+Keep in mind that BOA will run this command directly, so if you use relative paths (such as in
+the example in the previous sentence), then the working directory by default will be the directory
+that your config file is in. To add these run commands to your configuration file, add them
+to the following sections
+
+..  code-block:: YAML
+
+    script_options:
+        write_configs: whatever your write_configs run command is  # only include if you are using a `Write Configs Script`
+        run_model: whatever your run_model run command is
+        set_trial_status: whatever your set_trial_status run command is  # only include if you are using a `Set Trial Status Script`
+        fetch_trial_data: whatever your fetch_trial_data run command is  # only include if you are using a `Fetch Trial Data Script`
+
+Here is an example of a `Run Model Script` that handles setting the trial status and outputting
+the data back to BOA as well. So this script is all that is needed (other than the model itself,
+which in this case is a synthetic function called hartman6, but that is just a stand in for any
+black box model call).
+
+.. literalinclude:: ../../tests/scripts/other_langs/r_package_streamlined/run_model.R
+    :language: R
+
+-------------------------
+Python Interface
+-------------------------
+
+To create a model wrapper, you will create a child class of :doc:`BOA </index>`'s :class:`.BaseWrapper`
 class. :class:`.BaseWrapper` defines the core functions that must be defined in your model
 wrapper:
 

--- a/boa/wrappers/__init__.py
+++ b/boa/wrappers/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 """
 ########################
 Creating model wrappers
@@ -42,10 +43,13 @@ to the following sections
 ..  code-block:: YAML
 
     script_options:
-        write_configs: whatever your write_configs run command is  # only include if you are using a `Write Configs Script`
+        # only include `write_configs` if you are using a `Write Configs Script`
+        write_configs: whatever your write_configs run command is
         run_model: whatever your run_model run command is
-        set_trial_status: whatever your set_trial_status run command is  # only include if you are using a `Set Trial Status Script`
-        fetch_trial_data: whatever your fetch_trial_data run command is  # only include if you are using a `Fetch Trial Data Script`
+        # only include `set_trial_status` if you are using a `Set Trial Status Script`
+        set_trial_status: whatever your set_trial_status run command is
+        # only include `fetch_trial_data` if you are using a `Fetch Trial Data Script`
+        fetch_trial_data: whatever your fetch_trial_data run command is
 
 Here is an example of a `Run Model Script` that handles setting the trial status and outputting
 the data back to BOA as well. So this script is all that is needed (other than the model itself,

--- a/boa/wrappers/script_wrapper.py
+++ b/boa/wrappers/script_wrapper.py
@@ -285,8 +285,9 @@ class ScriptWrapper(BaseWrapper):
             func_names = [func_names]
         ran_cmds = False
         for func_name in func_names:
-            run_cmd = (self.config.get("script_options", {}).get(f"{func_name}")
-                       or self.config.get("script_options", {}).get(f"{func_name}_run_cmd"))
+            run_cmd = self.config.get("script_options", {}).get(f"{func_name}") or self.config.get(
+                "script_options", {}
+            ).get(f"{func_name}_run_cmd")
             if run_cmd:
                 ran_cmds = True
                 # TODO BaseTrial doesn't have arm property, just arms.

--- a/boa/wrappers/script_wrapper.py
+++ b/boa/wrappers/script_wrapper.py
@@ -285,7 +285,8 @@ class ScriptWrapper(BaseWrapper):
             func_names = [func_names]
         ran_cmds = False
         for func_name in func_names:
-            run_cmd = self.config.get("script_options", {}).get(f"{func_name}_run_cmd")
+            run_cmd = (self.config.get("script_options", {}).get(f"{func_name}")
+                       or self.config.get("script_options", {}).get(f"{func_name}_run_cmd"))
             if run_cmd:
                 ran_cmds = True
                 # TODO BaseTrial doesn't have arm property, just arms.

--- a/docs/user_guide/package_overview.rst
+++ b/docs/user_guide/package_overview.rst
@@ -24,9 +24,9 @@ When specifying your objective function to minimize or maximize, :doc:`BOA </ind
 
 
 
-************************
-Creating a model wrapper
-************************
+************************************************************************
+Creating a model wrapper (Language Agnostic or Python API)
+************************************************************************
 
 Using a model with :doc:`BOA </index>` requires writing a minimal wrapper to define the essential functions needed for
 :doc:`BOA </index>` to interact with the model (i.e. reading and writing configurations for the model, running the
@@ -37,7 +37,7 @@ and there is a standard interface to follow.
 See the :mod:`instructions for creating a model wrapper <.boa.wrappers>` for details.
 
 *********************************************
-Creating a run script (sometimes needed)
+Creating a run script (Usually Not Needed)
 *********************************************
 
 Most of the time you won't need to write a run script because BOA has an built-in run script in
@@ -59,7 +59,7 @@ you can start your run easily from the command line.
 
 With your conda environment for boa activated, run::
 
-    python -m boa --config_path path/to/your/config/file
+    python -m boa --config-path path/to/your/config/file
 
 or::
 

--- a/docs/user_guide/run_script.rst
+++ b/docs/user_guide/run_script.rst
@@ -12,12 +12,6 @@ A run script needs to initialize your wrapper, load your configuration, and run 
 Single Objective Optimization Run Scripts
 ===========================================
 
-.. rli:: https://raw.githubusercontent.com/jemissik/fetch3_nhl/develop/fetch3/optimize/run_optimization.py
-    :language: python
-
-link to source: https://github.com/jemissik/fetch3_nhl/blob/develop/fetch3/optimize/run_optimization.py
-
-
 .. rli:: https://raw.githubusercontent.com/madeline-scyphers/palm_wrapper/main/palm_wrapper/optimize/run.py
     :language: python
 

--- a/tests/scripts/other_langs/r_package_full/config.yaml
+++ b/tests/scripts/other_langs/r_package_full/config.yaml
@@ -39,10 +39,10 @@ parameters:
         'value_type': 'float'
 
 script_options:
-    write_configs_run_cmd: Rscript write_configs.R
-    run_model_run_cmd: Rscript run_model.R
-    set_trial_status_run_cmd: Rscript set_trial_status.R
-    fetch_trial_data_run_cmd: Rscript fetch_trial_data.R
+    write_configs: Rscript write_configs.R
+    run_model: Rscript run_model.R
+    set_trial_status: Rscript set_trial_status.R
+    fetch_trial_data: Rscript fetch_trial_data.R
 
 model_options:
     input_size: 15

--- a/tests/scripts/other_langs/r_package_full/fetch_trial_data.R
+++ b/tests/scripts/other_langs/r_package_full/fetch_trial_data.R
@@ -3,8 +3,7 @@ library(jsonlite)
 BRANIN_TRUE_MIN <- 0.397887
 
 args <- commandArgs(trailingOnly=TRUE)
-
-trial_dir <- args[1]
+trial_dir <- args[length(args)]
 
 model_data <- read_json(path=file.path(trial_dir, "model_data.json"))
 res <- model_data$output

--- a/tests/scripts/other_langs/r_package_full/fetch_trial_data.R
+++ b/tests/scripts/other_langs/r_package_full/fetch_trial_data.R
@@ -5,9 +5,11 @@ BRANIN_TRUE_MIN <- 0.397887
 args <- commandArgs(trailingOnly=TRUE)
 trial_dir <- args[length(args)]
 
+# Read in our data
 model_data <- read_json(path=file.path(trial_dir, "model_data.json"))
 res <- model_data$output
 
+# format and save our data to a format that BOA is expecting
 out_data <- list(
     mean=list(
         a=res

--- a/tests/scripts/other_langs/r_package_full/run_model.R
+++ b/tests/scripts/other_langs/r_package_full/run_model.R
@@ -1,50 +1,16 @@
 library(jsonlite)
+source("../r_utils/hartman6.R")
 
-# Maybe can use branin later?
-branin <- function(x1, x2) {
-
-    a <- 1
-    b <- 5.1/(4*pi^2)
-    c <- 5/pi
-    r <- 6
-    s <- 10
-    t <- 1/(8*pi)
-
-    term1 <- a * (x2 - b*x1^2 + c*x1 - r)^2
-    term2 <- s*(1-t)*cos(x1)
-
-    y <- term1 + term2 + s
-    return(y)
-}
-
-hartman6 <- function(X) {
-  alpha <- c(1.0, 1.2, 3.0, 3.2)
-  A <- c(10, 3, 17, 3.5, 1.7, 8,
-         0.05, 10, 17, 0.1, 8, 14,
-         3, 3.5, 1.7, 10, 17, 8,
-         17, 8, 0.05, 10, 0.1, 14)
-  A <- matrix(A, 4, 6, byrow=TRUE)
-  P <- 10^(-4) * c(1312, 1696, 5569, 124, 8283, 5886,
-                   2329, 4135, 8307, 3736, 1004, 9991,
-                   2348, 1451, 3522, 2883, 3047, 6650,
-                   4047, 8828, 8732, 5743, 1091, 381)
-  P <- matrix(P, 4, 6, byrow=TRUE)
-
-  Xmat <- matrix(rep(X,times=4), 4, 6, byrow=TRUE)
-  inner_sum <- rowSums(A[,1:6]*(Xmat-P[,1:6])^2)
-  outer_sum <- sum(alpha * exp(-inner_sum))
-  y <- -outer_sum
-  return(y)
-}
-
+# This is where we read in from BOA the command line argument.
+# If in your script, you use any other command line arguments,
+# generally BOA's trial_dir should be the last command line arugment,
+# so taking the last one should generally be safe.
 args <- commandArgs(trailingOnly=TRUE)
-
-trial_dir <- args[1]
+trial_dir <- args[length(args)]
 
 df <- read.csv(file = file.path(trial_dir, "data.csv"))
 X <- df[[1]]
 res <- hartman6(X)
-# res <- branin(x1, x2)
 
 out_data <- list(
     output=unbox(res)

--- a/tests/scripts/other_langs/r_package_full/run_model.R
+++ b/tests/scripts/other_langs/r_package_full/run_model.R
@@ -1,20 +1,23 @@
 library(jsonlite)
 source("../r_utils/hartman6.R")
 
-# This is where we read in from BOA the command line argument.
-# If in your script, you use any other command line arguments,
-# generally BOA's trial_dir should be the last command line arugment,
-# so taking the last one should generally be safe.
 args <- commandArgs(trailingOnly=TRUE)
 trial_dir <- args[length(args)]
 
+# Here we read the data we wrote out from our write_configs.R script
 df <- read.csv(file = file.path(trial_dir, "data.csv"))
 X <- df[[1]]
+
+# This is where we actually run our "model".
+# Here we are using a synthetic function called hartman6
+# But you could substitute it for your own model in
+# a number of ways.
 res <- hartman6(X)
 
+# Here we write out the data to wherever we want to store it,
+# in this case we use the trial_dir
 out_data <- list(
     output=unbox(res)
 )
 json_data <- toJSON(out_data, pretty = TRUE)
-print(json_data)
 write(json_data, file.path(trial_dir, "model_data.json"))

--- a/tests/scripts/other_langs/r_package_full/set_trial_status.R
+++ b/tests/scripts/other_langs/r_package_full/set_trial_status.R
@@ -1,7 +1,7 @@
 library(jsonlite)
 
 args <- commandArgs(trailingOnly=TRUE)
-trial_dir <- args[1]
+trial_dir <- args[length(args)]
 
 is_completed <- file.exists(file.path(trial_dir, "model_data.json"))
 

--- a/tests/scripts/other_langs/r_package_full/set_trial_status.R
+++ b/tests/scripts/other_langs/r_package_full/set_trial_status.R
@@ -3,13 +3,30 @@ library(jsonlite)
 args <- commandArgs(trailingOnly=TRUE)
 trial_dir <- args[length(args)]
 
-is_completed <- file.exists(file.path(trial_dir, "model_data.json"))
 
-if (is_completed) {
+# We read in the data we saved before.
+# If it is just your own output data, you can probably put this step
+# at the end of your Run Model Scipt. But if you don't know when
+# your model finishes because it is running on an HPC,
+# you could replace this with checks of the queue, or reading the log
+# file for certain statuses, or other techniques.
+data <- read_json(path=file.path(trial_dir, "model_data.json"))
+is_passed <- (!is.na(data$output))
+
+if (is_passed) {
+    # If we passed, we write out the trial status as COMPLETE
     trial_status <- "COMPLETED"
     out_data <- list(
         trial_status=unbox(trial_status)
     )
-    json_data <- toJSON(out_data, pretty = TRUE)
-    write(json_data, file.path(trial_dir, "trial_status.json"))
+
+} else {
+    # If we failed, we write out the trial status as FAILED
+    out_data <- list(
+        trial_status=unbox("FAILED")
+    )
 }
+
+# save to a trial_status.json file in the triad_dir
+json_data <- toJSON(out_data, pretty = TRUE)
+write(json_data, file.path(trial_dir, "trial_status.json"))

--- a/tests/scripts/other_langs/r_package_full/write_configs.R
+++ b/tests/scripts/other_langs/r_package_full/write_configs.R
@@ -1,11 +1,22 @@
+# load in any libraries and modules we need
 library(jsonlite)
 
+# This is where we read in from BOA the command line argument.
+# If in your script, you use any other command line arguments,
+# generally BOA's trial_dir should be the last command line arugment,
+# so taking the last one should generally be safe.
 args <- commandArgs(trailingOnly=TRUE)
 trial_dir <- args[length(args)]
 
+# this this trial_dir folder there are 2 files supplied by BOA,
+# a parameters.json that has just the parameters, and a trial.json
+# that includes the parameters and a lot more in case you need it.
+# Most people will only need the parameters.json
 param_path <- file.path(trial_dir, "parameters.json")
 data <- read_json(path=param_path)
 
+# The parameter keys config from whatever you  named them in your
+# config file, which you are free to change.
 x0 <- data$x0
 x1 <- data$x1
 x2 <- data$x2
@@ -13,8 +24,12 @@ x3 <- data$x3
 x4 <- data$x4
 x5 <- data$x5
 
+# We write out are data to another file for our run_model.R script
+# in a real use case, this could be writing out the parameters
+# to whatever config file your model needs whether it is
+# json, a text file, yaml, toml, netcdf, or anything else.
+# this just allows you to partition the conversion steps from
+# BOA parameters.json to what your model will read
 X <- c(x0, x1, x2, x3, x4, x5)
-
 df <- data.frame(X)
-
 write.csv(df, file.path(trial_dir, "data.csv"), row.names = FALSE)

--- a/tests/scripts/other_langs/r_package_full/write_configs.R
+++ b/tests/scripts/other_langs/r_package_full/write_configs.R
@@ -1,8 +1,8 @@
 library(jsonlite)
 
 args <- commandArgs(trailingOnly=TRUE)
+trial_dir <- args[length(args)]
 
-trial_dir <- args[1]
 param_path <- file.path(trial_dir, "parameters.json")
 data <- read_json(path=param_path)
 

--- a/tests/scripts/other_langs/r_package_light/config.yaml
+++ b/tests/scripts/other_langs/r_package_light/config.yaml
@@ -39,7 +39,7 @@ parameters:
         'value_type': 'float'
 
 script_options:
-    run_model_run_cmd: Rscript run_model.R
+    run_model: Rscript run_model.R
 
 model_options:
     input_size: 15

--- a/tests/scripts/other_langs/r_package_light/run_model.R
+++ b/tests/scripts/other_langs/r_package_light/run_model.R
@@ -1,36 +1,13 @@
 library(jsonlite)
+source("../r_utils/hartman6.R")
 
-hartman6 <- function(X) {
-     out <- tryCatch(
-     {
-          alpha <- c(1.0, 1.2, 3.0, 3.2)
-          A <- c(10, 3, 17, 3.5, 1.7, 8,
-                 0.05, 10, 17, 0.1, 8, 14,
-                 3, 3.5, 1.7, 10, 17, 8,
-                 17, 8, 0.05, 10, 0.1, 14)
-          A <- matrix(A, 4, 6, byrow=TRUE)
-          P <- 10^(-4) * c(1312, 1696, 5569, 124, 8283, 5886,
-                           2329, 4135, 8307, 3736, 1004, 9991,
-                           2348, 1451, 3522, 2883, 3047, 6650,
-                           4047, 8828, 8732, 5743, 1091, 381)
-          P <- matrix(P, 4, 6, byrow=TRUE)
-
-          Xmat <- matrix(rep(X,times=4), 4, 6, byrow=TRUE)
-          inner_sum <- rowSums(A[,1:6]*(Xmat-P[,1:6])^2)
-          outer_sum <- sum(alpha * exp(-inner_sum))
-          y <- -outer_sum
-          return(y)
-     },
-       error=function(cond) {
-            return(NA)
-        }
-     )
-    return(out)
-}
-
+# This is where we read in from BOA the command line argument.
+# If in your script, you use any other command line arguments,
+# generally BOA's trial_dir should be the last command line arugment,
+# so taking the last one should generally be safe.
 args <- commandArgs(trailingOnly=TRUE)
+trial_dir <- args[length(args)]
 
-trial_dir <- args[1]
 param_path <- file.path(trial_dir, "parameters.json")
 data <- read_json(path=param_path)
 
@@ -41,13 +18,12 @@ x3 <- data$x3
 x4 <- data$x4
 x5 <- data$x5
 X <- c(x0, x1, x2, x3, x4, x5)
-print(X)
+
 res <- hartman6(X)
 
 if (!is.na(res)) {
-    trial_status <- "COMPLETED"
     out_data <- list(
-        TrialStatus=unbox(trial_status)
+        TrialStatus=unbox("COMPLETED")
     )
     json_data <- toJSON(out_data, pretty = TRUE)
     write(json_data, file.path(trial_dir, "TrialStatus.json"))
@@ -62,9 +38,8 @@ if (!is.na(res)) {
     json_data <- toJSON(out_data, pretty = TRUE)
     write(json_data, file.path(trial_dir, "output.json"))
 } else {
-    trial_status <- "FAILED"
     out_data <- list(
-        TrialStatus=unbox(trial_status)
+        TrialStatus=unbox("FAILED")
     )
     json_data <- toJSON(out_data, pretty = TRUE)
     write(json_data, file.path(trial_dir, "TrialStatus.json"))

--- a/tests/scripts/other_langs/r_package_streamlined/config.yaml
+++ b/tests/scripts/other_langs/r_package_streamlined/config.yaml
@@ -39,7 +39,7 @@ parameters:
         'value_type': 'float'
 
 script_options:
-    run_model_run_cmd: Rscript run_model.R
+    run_model: Rscript run_model.R
 
 model_options:
     input_size: 15

--- a/tests/scripts/other_langs/r_package_streamlined/config_fail.yaml
+++ b/tests/scripts/other_langs/r_package_streamlined/config_fail.yaml
@@ -34,7 +34,7 @@ parameters:
         'type': 'choice'
 
 script_options:
-    run_model_run_cmd: Rscript run_model.R
+    run_model: Rscript run_model.R
 
 model_options:
     input_size: 15

--- a/tests/scripts/other_langs/r_package_streamlined/run_model.R
+++ b/tests/scripts/other_langs/r_package_streamlined/run_model.R
@@ -42,7 +42,6 @@ if (!is.na(res)) {
 
     # if it was a success, we don't even need to write out trial status,
     # it is assumed a success if we write out data and don't fail
-
     out_data <- list(
         mean=list(
             a=res
@@ -50,15 +49,13 @@ if (!is.na(res)) {
         # trial_status=unbox("COMPLETED")  #  this is optional if it succeeds
     )
 
-    json_data <- toJSON(out_data, pretty = TRUE)
-    write(json_data, file.path(trial_dir, "output.json"))
 } else {
 
     # If we fail, then we do need to include a trial status, and mark it as failed.
-
     out_data <- list(
         trial_status=unbox("FAILED")
     )
-    json_data <- toJSON(out_data, pretty = TRUE)
-    write(json_data, file.path(trial_dir, "output.json"))
 }
+
+json_data <- toJSON(out_data, pretty = TRUE)
+write(json_data, file.path(trial_dir, "output.json"))

--- a/tests/scripts/other_langs/r_utils/hartman6.R
+++ b/tests/scripts/other_langs/r_utils/hartman6.R
@@ -1,0 +1,27 @@
+hartman6 <- function(X) {
+     out <- tryCatch(
+     {
+          alpha <- c(1.0, 1.2, 3.0, 3.2)
+          A <- c(10, 3, 17, 3.5, 1.7, 8,
+                 0.05, 10, 17, 0.1, 8, 14,
+                 3, 3.5, 1.7, 10, 17, 8,
+                 17, 8, 0.05, 10, 0.1, 14)
+          A <- matrix(A, 4, 6, byrow=TRUE)
+          P <- 10^(-4) * c(1312, 1696, 5569, 124, 8283, 5886,
+                           2329, 4135, 8307, 3736, 1004, 9991,
+                           2348, 1451, 3522, 2883, 3047, 6650,
+                           4047, 8828, 8732, 5743, 1091, 381)
+          P <- matrix(P, 4, 6, byrow=TRUE)
+
+          Xmat <- matrix(rep(X,times=4), 4, 6, byrow=TRUE)
+          inner_sum <- rowSums(A[,1:6]*(Xmat-P[,1:6])^2)
+          outer_sum <- sum(alpha * exp(-inner_sum))
+          y <- -outer_sum
+          return(y)
+     },
+       error=function(cond) {
+            return(NA)
+        }
+     )
+    return(out)
+}


### PR DESCRIPTION
Add to the `boa.wrappers.__init__.py` `__doc__` information about the lang agnostic implementation, how to input it from your config, what each part does, and the first example. In the example, each part is broken down with a comment explaining what it does.