### PR TITLE
docs: enable downloadable formats on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,3 +18,4 @@ sphinx:
 # Build PDF & ePub
 formats:
   - pdf
+  - epub

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,6 @@ conda:
 sphinx:
   fail_on_warning: true
 
-# Build PDF
+# Build PDF (ePuB causes "duplicated ToC entry found" between html pages and the epub xhtml pages)
 formats:
   - pdf

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,5 +15,6 @@ conda:
 sphinx:
   fail_on_warning: true
 
-# Build all downloadable formats
-formats: all
+# Build PDF & ePub
+formats:
+  - pdf

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,6 @@ conda:
 
 sphinx:
   fail_on_warning: true
+
+# Build all downloadable formats
+formats: all

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,6 @@ conda:
 sphinx:
   fail_on_warning: true
 
-# Build PDF & ePub
+# Build PDF
 formats:
   - pdf
-  - epub


### PR DESCRIPTION
Enable building downloadable doc formats on readthedocs. Downloadable versions of the docs will be available in the flyout menu (pdf, ePub, and zipped html).