### PR TITLE
Add stderr and stdinn pipes for subproess.Popen

### DIFF
--- a/boa/wrappers/script_wrapper.py
+++ b/boa/wrappers/script_wrapper.py
@@ -303,7 +303,9 @@ class ScriptWrapper(BaseWrapper):
                 #     file.write(json.dumps(data))
 
                 args = split_shell_command(f"{run_cmd} {trial_dir}")
-                p = subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True)
+                p = subprocess.Popen(
+                    args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, universal_newlines=True
+                )
                 if block:
                     p.communicate()
                 # TODO move polling and print to another thread so it doesn't block but still writes to log?


### PR DESCRIPTION
Some models write to stderr in addition to stdout, and if stderr is not piped by BOA,
those models can crash (see SWAT as an example). In addition, add stdin pipe as well
to allow people the option to write to stdin if they want that ability. Though there are
no use cases at the moment.