### PR TITLE
Bugfix/reload scheduler workaround

### DIFF
--- a/boa/storage.py
+++ b/boa/storage.py
@@ -35,8 +35,13 @@ from boa.logger import get_logger
 from boa.metrics.modular_metric import ModularMetric
 from boa.runner import WrappedJobRunner
 from boa.scheduler import Scheduler
-from boa.utils import _load_attr_from_module, _load_module_from_path
+from boa.utils import (
+    _load_attr_from_module,
+    _load_module_from_path,
+    get_dictionary_from_callable,
+)
 from boa.wrappers.base_wrapper import BaseWrapper
+from boa.wrappers.script_wrapper import ScriptWrapper
 
 logger = get_logger()
 
@@ -92,12 +97,10 @@ def scheduler_to_json_snapshot(
     options = SchedulerOptions(**options)
 
     try:
-        wrapper_serialization = (
-            object_to_json(
-                scheduler.experiment.runner.wrapper,
-                encoder_registry=encoder_registry,
-                class_encoder_registry=class_encoder_registry,
-            ),
+        wrapper_serialization = object_to_json(
+            scheduler.experiment.runner.wrapper,
+            encoder_registry=encoder_registry,
+            class_encoder_registry=class_encoder_registry,
         )
     except AXJSONEncodeError as e:
         logger.error(e)
@@ -159,6 +162,9 @@ def scheduler_from_json_snapshot(
     wrapper = None
     if "wrapper" in serialized:
         wrapper_dict = serialized.pop("wrapper", {})
+        # sometimes the way people write their to_dict methods wrap it in a list
+        if isinstance(wrapper_dict, list) and len(wrapper_dict) == 1:
+            wrapper_dict = wrapper_dict[0]
 
         try:
             wrapper = object_from_json(
@@ -166,7 +172,7 @@ def scheduler_from_json_snapshot(
                 decoder_registry=decoder_registry,
                 class_decoder_registry=class_decoder_registry,
             )
-        except Exception:
+        except Exception as e:
             deserialized = recursive_deserialize(
                 wrapper_dict,
                 decoder_registry=decoder_registry,
@@ -184,8 +190,10 @@ def scheduler_from_json_snapshot(
                 wrapper = WrapperCls.from_dict(**wrapper_dict)
 
             else:
-                logger.exception("Failed to deserialize wrapper.\n\n\n\n\n")
-                wrapper = BaseWrapper()
+                logger.exception(
+                    f"Failed to deserialize wrapper because of: {e!r}" f"\n\nUsing basic ScriptWrapper as back up"
+                )
+                wrapper = ScriptWrapper.from_dict(**get_dictionary_from_callable(ScriptWrapper.from_dict, wrapper_dict))
 
     serialized_generation_strategy = serialized.pop("generation_strategy")
     generation_strategy = generation_strategy_from_json(
@@ -209,7 +217,7 @@ def recursive_deserialize(obj, **kwargs):
             if "__type" not in obj:  # at least this out dict isn't serialized in AX format, let's check inners
                 raise AXJSONDecodeError("obj is not a AX JSON deserializable object")
             obj = object_from_json(obj, **kwargs)
-        except AXJSONDecodeError:
+        except (AXJSONDecodeError, TypeError):  # TypeError until https://github.com/facebook/Ax/pull/1418 is merged
             for key, value in obj.items():
                 obj[key] = recursive_deserialize(value, **kwargs)
     return obj


### PR DESCRIPTION
- [Add a workaround for the scheduler not deserializing properly until ax#1418 is merged](https://github.com/madeline-scyphers/boa/commit/98b847c3c973ebe7315e5c2efd878e633699e7a8)
Now it will try and deserialize, then it will try
and reload locally, then it will fall back on ScriptWrapper
Which should be a fine fallback for now.
- [Add ability for WRapperJobRunner to launch jobs in threads](https://github.com/madeline-scyphers/boa/commit/118c4260d8b1ff6b4ec72f7e4089c451d3c6df9d)  …
WrappedJobRunner before launched jobs in seq, now it will
launch them in threads at once. While doing this this also
opened up the ability to make the opoen process in
SciptWrapper run_script read from stdout since it is
no longer blocking