### PR TITLE
Rename package for publishing to boa-framework but import is still boa

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on: push
+
+jobs:
+    build-n-publish:
+        name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+        runs-on: "ubuntu-latest"
+
+        steps:
+            -   uses: actions/checkout@master
+            -   name: Set up Python 3.9
+                uses: actions/setup-python@v1
+                with:
+                    python-version: 3.9
+
+            -   name: Install build dependencies
+                run: |
+                    python -m pip install -e .
+                    python -m pip install build
+
+            -   name: Build a binary wheel and a source tarball
+                run: python -m build
+
+#            -   name: Publish distribution 📦 to Test PyPI
+#                uses: pypa/gh-action-pypi-publish@release/v1
+#                with:
+#                    password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+#                    repository-url: https://test.pypi.org/legacy/
+
+            -   name: Publish distribution 📦 to PyPI
+                if: startsWith(github.ref, 'refs/tags')
+                uses: pypa/gh-action-pypi-publish@release/v1
+                with:
+                    password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "boa"
+name = "pyboa"
 description = "Bayesian Optimization for Anything: A high-level Bayesian optimization framework and model wrapping tool. It provides an easy-to-use interface between models and the python libraries Ax and BoTorch."
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pyboa"
+name = "boa-framework"
 description = "Bayesian Optimization for Anything: A high-level Bayesian optimization framework and model wrapping tool. It provides an easy-to-use interface between models and the python libraries Ax and BoTorch."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Rename package for publishing to boa-framework but import is still boa since PyPI and conda both have a boa already. This way people will install boa-framework but it'll still be `import boa`