### PR TITLE
various minor bugfixes, see changelog

### DIFF
--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -46,19 +46,6 @@ from boa.wrappers.wrapper_utils import cd_and_cd_back, load_jsonlike
     " This requires your Wrapper to have the ability to take experiment_dir as an argument"
     " to ``load_config``. The default ``load_config`` does support this.",
 )
-# @click.option(
-#     "-rel",
-#     "--rel-to-here",
-#     is_flag=True,
-#     show_default=True,
-#     default=False,
-#     help="Define all path and dir options in your config file relative to where boa is launch from"
-#     " instead of relative to the config file location (the default)"
-#     " ex:"
-#     " given working_dir=path/to/dir"
-#     " if you don't pass --rel_to_here then path/to/dir is defined in terms of where your config file is"
-#     " if you do pass --rel_to_here then path/to/dir is defined in terms of where you launch boa from",
-# )
 @click.option(
     "--rel-to-config/--rel-to-here",  # more cli friendly name for config option of rel_to_launch
     # default=fields_dict(BOAConfig)["rel_to_config"].default,  # make default opposite of rel_to_config
@@ -71,8 +58,7 @@ from boa.wrappers.wrapper_utils import cd_and_cd_back, load_jsonlike
     " if you do pass --rel-to-here then path/to/dir is defined in terms of where you launch boa from",
 )
 def main(config_path, scheduler_path, wrapper_path, temporary_dir, rel_to_config):
-    # config_path = config_path if config_path else None
-    # scheduler_path = scheduler_path if scheduler_path else None
+    """Run experiment run from config path or scheduler path"""
 
     if temporary_dir:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -100,13 +86,9 @@ def run(config_path, scheduler_path, rel_to_config, wrapper_path=None, experimen
         Path to where file where your wrapper is located. Used when loaded from scheduler json file,
          and the path to your wrapper has changed (such as when loading on a different computer then
          originally ran from).
-    rel_to_here
-        Define all path and dir options in your config file relative to where boa is launch from"
-        instead of relative to the config file location (the default)"
-        ex:
-        given working_dir=path/to/dir
-        if you don't pass --rel_to_here then path/to/dir is defined in terms of where your config file is
-        if you do pass --rel_to_here then path/to/dir is defined in terms of where you launch boa from
+    rel_to_config
+        Define all path and dir options in your config file relative to to your config file location
+        or rel_to_here (relative to cli launch)
     experiment_dir
         experiment output directory to save BOA run to, can only be specified during an initial run
         (when passing in a config_path, not a scheduler_path)
@@ -121,7 +103,7 @@ def run(config_path, scheduler_path, rel_to_config, wrapper_path=None, experimen
         config = load_jsonlike(config_path)
         script_options = config.get("script_options", {})
         if rel_to_config is None:
-            rel_to_config = script_options.get("rel_to_config", None) or script_options.get("rel_to_launch", None)
+            rel_to_config = script_options.get("rel_to_config", None) or not script_options.get("rel_to_launch", None)
             if rel_to_config is None:
                 rel_to_config = (
                     fields_dict(BOAScriptOptions)["rel_to_config"].default

--- a/boa/ax_instantiation_utils.py
+++ b/boa/ax_instantiation_utils.py
@@ -100,7 +100,7 @@ def get_experiment(config: BOAConfig, runner: Runner, wrapper: BaseWrapper = Non
         optimization_config=optimization_config,
         runner=runner,
         tracking_metrics=info_only_metrics,
-        name=config.name,
+        name=config.script_options.exp_name,
     )
     # we use getattr here in case someone subclassed without the proper super calls
     if not getattr(wrapper, "metric_names", None):

--- a/boa/config/config.py
+++ b/boa/config/config.py
@@ -304,6 +304,13 @@ class BOAScriptOptions(_Utils):
             to whatever pwd returns (and equivalent on windows))"""
         },
     )
+    exp_name: Optional[str] = field(
+        default="boa_runs",
+        metadata={
+            "doc": """name of the experiment. Used with output_dir to create the experiment directory
+            if experiment_dir is not specified."""
+        },
+    )
     append_timestamp: bool = field(
         default=True,
         metadata={
@@ -500,7 +507,6 @@ For specific options you can pass to each step
             ),
         },
     )
-    name: str = "boa_runs"
     parameter_constraints: list[str] = Factory(list)
     model_options: Optional[dict | list] = None
     script_options: Optional[dict | BOAScriptOptions] = field(
@@ -639,7 +645,9 @@ For specific options you can pass to each step
         #####################################################
         #  copy over experiment name
         if "name" in opt_ops.get("experiment", {}):
-            config["name"] = opt_ops["experiment"]["name"]
+            if not config.get("script_options"):
+                config["script_options"] = {}
+            config["script_options"]["exp_name"] = opt_ops["experiment"]["name"]
 
         return config
 

--- a/boa/config/config.py
+++ b/boa/config/config.py
@@ -348,9 +348,20 @@ class BOAScriptOptions(_Utils):
         default=".",
     )
 
-    def __attrs_post_init__(self):
-        if (self.rel_to_config and self.rel_to_launch) or (not self.rel_to_config and not self.rel_to_launch):
+    def __init__(self, **config):
+        rel_to_config = config.get("rel_to_config", None)
+        rel_to_launch = config.get("rel_to_launch", None)
+        if rel_to_config and rel_to_launch:
             raise TypeError("Must specify exactly one of rel_to_here or rel_to_config")
+
+        if rel_to_launch:
+            config["rel_to_config"] = False
+        if rel_to_config:
+            config["rel_to_launch"] = False
+
+        self.__attrs_init__(**config)
+
+    def __attrs_post_init__(self):
 
         if not self.base_path:
             if self.rel_to_config:

--- a/boa/config/config.py
+++ b/boa/config/config.py
@@ -358,7 +358,6 @@ class BOAScriptOptions(_Utils):
             config["rel_to_config"] = False
         if rel_to_config:
             config["rel_to_launch"] = False
-
         self.__attrs_init__(**config)
 
     def __attrs_post_init__(self):

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -209,7 +209,7 @@ class BaseWrapper(metaclass=WrapperRegister):
         # grab exp dir from config file or if passed in
         experiment_dir = experiment_dir or self.config.script_options.experiment_dir
         output_dir = output_dir or self.config.script_options.output_dir
-        experiment_name = experiment_name or self.config.name
+        experiment_name = experiment_name or self.config.script_options.exp_name
         append_timestamp = append_timestamp or self.script_options.append_timestamp
         if experiment_dir:
             mk_exp_dir_kw = dict(experiment_dir=experiment_dir, append_timestamp=append_timestamp, **kwargs)

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -97,7 +97,7 @@ class BaseWrapper(metaclass=WrapperRegister):
         for metric in self._config.objective.metrics:
             if metric.properties:
                 name = metric.name
-                metric_propertis[name] = metric["properties"]
+                metric_propertis[name] = metric.properties
 
         self._metric_properties = metric_propertis
 


### PR DESCRIPTION
- [Fix bug in __main__ where it wouldn't read config rel_to_launch properly](https://github.com/madeline-scyphers/boa/pull/137/commits/df3204bae16f7dd28ee8af9a17ca62be96dfa66f)
- [move exp_name into script options](https://github.com/madeline-scyphers/boa/pull/137/commits/236daa4bd80c4291cee1220c3830bdd7fa3ae593)
- [Fix ScriptOptions bug that didn't override rel_to_config right on rel_to_launch](https://github.com/madeline-scyphers/boa/pull/137/commits/3fe8fb5b2ba2e7650ad3e2fd66dafe9d97b76cba)
- [Fix bug with BaseWrapper trying to set metric properties as dict instead of as class attribute now
](https://github.com/madeline-scyphers/boa/pull/137/commits/64e3e7fb1b7b009c0bcf982078f3e12f7bf71754)  
