### PR TITLE
Wrapper serialization update

### DIFF
--- a/boa/__main__.py
+++ b/boa/__main__.py
@@ -36,6 +36,13 @@ from boa.wrappers.wrapper_utils import cd_and_cd_back, load_jsonlike
     " originally ran from).",
 )
 @click.option(
+    "-wn",
+    "--wrapper-name",
+    type=str,
+    default="",
+    help="Name of the wrapper class to use. Used when loaded from scheduler json file,",
+)
+@click.option(
     "-td",
     "--temporary-dir",
     is_flag=True,
@@ -56,7 +63,7 @@ from boa.wrappers.wrapper_utils import cd_and_cd_back, load_jsonlike
     " if you don't pass --rel-to-here then path/to/dir is defined in terms of where your config file is"
     " if you do pass --rel-to-here then path/to/dir is defined in terms of where you launch boa from",
 )
-def main(config_path, scheduler_path, wrapper_path, temporary_dir, rel_to_config):
+def main(config_path, scheduler_path, wrapper_path, wrapper_name, temporary_dir, rel_to_config):
     """Run experiment run from config path or scheduler path"""
 
     if temporary_dir:
@@ -66,13 +73,14 @@ def main(config_path, scheduler_path, wrapper_path, temporary_dir, rel_to_config
                 config_path,
                 scheduler_path=scheduler_path,
                 wrapper_path=wrapper_path,
+                wrapper_name=wrapper_name,
                 rel_to_config=rel_to_config,
                 experiment_dir=experiment_dir,
             )
     return run(config_path, scheduler_path=scheduler_path, wrapper_path=wrapper_path, rel_to_config=rel_to_config)
 
 
-def run(config_path, scheduler_path, rel_to_config, wrapper_path=None, experiment_dir=None):
+def run(config_path, scheduler_path, rel_to_config, wrapper_path=None, wrapper_name=None, experiment_dir=None):
     """Run experiment run from config path or scheduler path
 
     Parameters
@@ -125,6 +133,9 @@ def run(config_path, scheduler_path, rel_to_config, wrapper_path=None, experimen
         )
     else:
         options = dict(scheduler_path=scheduler_path, working_dir=Path.cwd(), wrapper_path=wrapper_path)
+
+    if wrapper_name:
+        options["wrapper_name"] = wrapper_name
 
     with cd_and_cd_back(options["working_dir"]):
         if scheduler_path:

--- a/boa/metaclasses.py
+++ b/boa/metaclasses.py
@@ -57,19 +57,55 @@ class WrapperRegister(ABCMeta):
             _path = None
         cls._path = _path
         super().__init__(*args, **kwargs)
+        check = 0
+        if cls not in CORE_ENCODER_REGISTRY:
+            CORE_ENCODER_REGISTRY[cls] = cls.to_dict
+            check += 1
+        if cls.__name__ not in CORE_DECODER_REGISTRY:
+            CORE_DECODER_REGISTRY[cls.__name__] = cls.from_dict
+            check += 1
+        elif CORE_DECODER_REGISTRY[cls.__name__].__self__.path() == cls.path():
+            # When we dynamically reload a module, the class is already registered
+            # But the class is not the same object as the one we are trying to register
+            check = 2
+        if check != 2:
+            raise ValueError(
+                f"Wrapper defined in {cls.__module__} already registered. "
+                "Please use a different name for your Wrapper class."
+            )
 
 
 class RunnerRegister(ABCMeta):
     def __init__(cls, *args, **kwargs):
-        CORE_ENCODER_REGISTRY[cls] = cls.to_dict
-        CORE_DECODER_REGISTRY[cls.__name__] = cls
-        next_pk = max(CORE_RUNNER_REGISTRY.values()) + 1
-        CORE_RUNNER_REGISTRY[cls] = next_pk
+        check = 0
+        if cls not in CORE_ENCODER_REGISTRY:
+            CORE_ENCODER_REGISTRY[cls] = cls.to_dict
+            next_pk = max(CORE_RUNNER_REGISTRY.values()) + 1
+            CORE_RUNNER_REGISTRY[cls] = next_pk
+            check += 1
+        if cls.__name__ not in CORE_DECODER_REGISTRY:
+            CORE_DECODER_REGISTRY[cls.__name__] = cls
+            check += 1
+        if check != 2:
+            raise ValueError(
+                f"Runner defined in {cls.__module__} already registered. "
+                "Please use a different name for your Runner class."
+            )
 
 
 class MetricRegister(ABCMeta):
     def __init__(cls, *args, **kwargs):
-        CORE_ENCODER_REGISTRY[cls] = cls.to_dict
-        CORE_DECODER_REGISTRY[cls.__name__] = cls
-        next_pk = max(CORE_METRIC_REGISTRY.values()) + 1
-        CORE_METRIC_REGISTRY[cls] = next_pk
+        check = 0
+        if cls not in CORE_ENCODER_REGISTRY:
+            CORE_ENCODER_REGISTRY[cls] = cls.to_dict
+            next_pk = max(CORE_METRIC_REGISTRY.values()) + 1
+            CORE_METRIC_REGISTRY[cls] = next_pk
+            check += 1
+        if cls.__name__ not in CORE_DECODER_REGISTRY:
+            CORE_DECODER_REGISTRY[cls.__name__] = cls
+            check += 1
+        if check != 2:
+            raise ValueError(
+                f"Metric defined in {cls.__module__} already registered. "
+                "Please use a different name for your Metric class."
+            )

--- a/boa/metrics/metric_funcs.py
+++ b/boa/metrics/metric_funcs.py
@@ -65,7 +65,7 @@ def setup_sklearn_metric(metric_to_eval, instantiate=True, **kw):
     import boa.metrics.metrics
 
     def modular_sklearn_metric(**kwargs):
-        return boa.metrics.metrics.SklearnMetric(
+        return boa.metrics.metrics.BOASklearnMetric(
             **{"name": metric_to_eval, **kw, **kwargs, "metric_to_eval": metric_to_eval}
         )
 

--- a/boa/metrics/metrics.py
+++ b/boa/metrics/metrics.py
@@ -137,7 +137,7 @@ passthrough = PassThroughMetric
 pass_through_metric = PassThroughMetric
 
 
-class SklearnMetric(ModularMetric):
+class BOASklearnMetric(ModularMetric):
     """A subclass of ModularMetric where you can pass in a string name of a metric from
     sklrean.metrics, and BOA will grab that metric and create a BOA metric class for you.
 
@@ -156,7 +156,7 @@ class SklearnMetric(ModularMetric):
         super().__init__(metric_to_eval=metric_to_eval, *args, **kwargs)
 
 
-class MeanSquaredError(SklearnMetric):
+class MeanSquaredError(BOASklearnMetric):
     """
     Mean squared error regression loss.
 
@@ -178,7 +178,7 @@ MSE = MeanSquaredError
 mean_squared_error = MSE
 
 
-class RootMeanSquaredError(SklearnMetric):
+class RootMeanSquaredError(BOASklearnMetric):
     """
     Root mean squared error regression loss.
 
@@ -215,7 +215,7 @@ RMSE = RootMeanSquaredError
 root_mean_squared_error = RMSE
 
 
-class RSquared(SklearnMetric):
+class RSquared(BOASklearnMetric):
     """
     :math:`R^2` (coefficient of determination) regression score function.
 

--- a/boa/registry.py
+++ b/boa/registry.py
@@ -23,8 +23,6 @@ def _add_common_encodes_and_decodes():
         BOAScriptOptions,
         MetricType,
     )
-    from boa.wrappers.base_wrapper import BaseWrapper
-    from boa.wrappers.script_wrapper import ScriptWrapper
 
     for cls in [BOAObjective, BOAMetric, BOAScriptOptions, BOAConfig]:
         CORE_ENCODER_REGISTRY[cls] = attrs_to_dict
@@ -32,8 +30,3 @@ def _add_common_encodes_and_decodes():
 
     # CORE_ENCODER_REGISTRY[MetricType] = str(MetricType)
     CORE_DECODER_REGISTRY[MetricType.__name__] = MetricType
-
-    CORE_ENCODER_REGISTRY[BaseWrapper] = BaseWrapper.to_dict
-    CORE_DECODER_REGISTRY[BaseWrapper.__name__] = BaseWrapper.from_dict
-    CORE_ENCODER_REGISTRY[ScriptWrapper] = ScriptWrapper.to_dict
-    CORE_DECODER_REGISTRY[ScriptWrapper.__name__] = ScriptWrapper.from_dict

--- a/boa/scripts/moo.py
+++ b/boa/scripts/moo.py
@@ -16,7 +16,7 @@ Problem = get_synth_func("BraninCurrin")
 problem = Problem(negate=True).to(**tkwargs)
 
 
-class Wrapper(BaseWrapper):
+class WrapperMoo(BaseWrapper):
     def run_model(self, trial) -> None:
         pass
 
@@ -34,7 +34,7 @@ def main():
     with tempfile.TemporaryDirectory() as temp_dir:
         experiment_dir = Path(temp_dir)
         config_path = Path(__file__).resolve().parent / "moo.yaml"
-        wrapper = Wrapper(config_path=config_path, experiment_dir=experiment_dir)
+        wrapper = WrapperMoo(config_path=config_path, experiment_dir=experiment_dir)
         controller = Controller(wrapper=wrapper)
         controller.initialize_scheduler()
         return controller.run()

--- a/boa/scripts/moo.yaml
+++ b/boa/scripts/moo.yaml
@@ -26,3 +26,4 @@ parameters:
 
 script_options:
     exp_name: "moo_run"
+    wrapper_name: WrapperMoo

--- a/boa/scripts/run_branin.py
+++ b/boa/scripts/run_branin.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from ax.service.utils.report_utils import exp_to_df
 
 try:
-    from script_wrappers import Wrapper  # pragma: no cover
+    from script_wrappers import BraninWrapper  # pragma: no cover
 except ImportError:
-    from .script_wrappers import Wrapper
+    from .script_wrappers import BraninWrapper
 
 from boa import (
     BOAConfig,
@@ -30,7 +30,7 @@ def main():
 def run_opt(exp_dir):
     config_file = Path(__file__).parent / "synth_func_config.yaml"
     start = time.time()
-    wrapper = Wrapper(config_path=config_file, experiment_dir=exp_dir)
+    wrapper = BraninWrapper(config_path=config_file, experiment_dir=exp_dir)
     config: BOAConfig = wrapper.config
     experiment_dir = wrapper.experiment_dir
     # Copy the experiment config to the experiment directory

--- a/boa/scripts/script_wrappers.py
+++ b/boa/scripts/script_wrappers.py
@@ -10,7 +10,7 @@ import boa
 from boa.definitions import TEST_SCRIPTS_DIR
 
 
-class Wrapper(boa.BaseWrapper):
+class BraninWrapper(boa.BaseWrapper):
     _processes = []
     # Use default BaseWrapper methods for everything but methods below
 
@@ -54,5 +54,5 @@ class Wrapper(boa.BaseWrapper):
 
 
 def exit_handler():
-    for process in Wrapper._processes:
+    for process in BraninWrapper._processes:
         process.kill()

--- a/boa/scripts/synth_func_config.yaml
+++ b/boa/scripts/synth_func_config.yaml
@@ -30,5 +30,5 @@ model_options:
 
 script_options:
     wrapper_path: ./script_wrappers.py
-    wrapper_name: Wrapper
+    wrapper_name: BraninWrapper
     append_timestamp: True

--- a/boa/storage.py
+++ b/boa/storage.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 from dataclasses import asdict
 from typing import Any, Callable, Dict, Optional, Type
 
+from ax.exceptions.core import AxError
 from ax.exceptions.storage import JSONDecodeError as AXJSONDecodeError
 from ax.exceptions.storage import JSONEncodeError as AXJSONEncodeError
 from ax.service.scheduler import SchedulerOptions
@@ -186,7 +187,7 @@ def scheduler_from_json_snapshot(
                 decoder_registry=decoder_registry,
                 class_decoder_registry=class_decoder_registry,
             )
-        except Exception as e:
+        except Exception as e:  # pragma: no cover  # The only way to test this is to have a bad wrapper
             deserialized = recursive_deserialize(
                 wrapper_dict,
                 decoder_registry=decoder_registry,
@@ -202,14 +203,8 @@ def scheduler_from_json_snapshot(
                     module = _load_module_from_path(path)
                     WrapperCls: Type[BaseWrapper] = _load_attr_from_module(module, wrapper_dict["name"])
                     wrapper = WrapperCls.from_dict(**{**wrapper_dict, "config": config})
-                except Exception:
-                    logger.exception(
-                        f"Failed to deserialize wrapper because of: {e!r}" f"\n\nUsing basic ScriptWrapper as back up"
-                    )
-                    exit()
-                    wrapper = ScriptWrapper.from_dict(
-                        **{**get_dictionary_from_callable(ScriptWrapper.from_dict, wrapper_dict), "config": config}
-                    )
+                except Exception as e:
+                    raise AxError(f"Failed to deserialize wrapper because of: {e!r}")
 
             else:
                 logger.exception(

--- a/boa/storage.py
+++ b/boa/storage.py
@@ -172,7 +172,7 @@ def scheduler_from_json_snapshot(
     if "wrapper" in serialized:
         wrapper_dict = serialized.pop("wrapper", {})
         config = object_from_json(
-            wrapper_dict["config"],
+            deepcopy(wrapper_dict["config"]),
             decoder_registry=decoder_registry,
             class_decoder_registry=class_decoder_registry,
         )
@@ -206,6 +206,7 @@ def scheduler_from_json_snapshot(
                     logger.exception(
                         f"Failed to deserialize wrapper because of: {e!r}" f"\n\nUsing basic ScriptWrapper as back up"
                     )
+                    exit()
                     wrapper = ScriptWrapper.from_dict(
                         **{**get_dictionary_from_callable(ScriptWrapper.from_dict, wrapper_dict), "config": config}
                     )

--- a/boa/utils.py
+++ b/boa/utils.py
@@ -166,7 +166,7 @@ def serialize_init_args(class_, *, parents: list[Type] = None, match_private: bo
 def _load_module_from_path(module_path: PathLike, module_name: str = None) -> types.ModuleType:
     """Load a module dynamically from a path"""
     if module_name is None:
-        module_name = Path(module_path).name
+        module_name = Path(module_path).stem
     sys.path.append(str(Path(module_path).parent))
     # create a module spec from a file location, so we can then load that module
     spec = importlib.util.spec_from_file_location(module_name, module_path)

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -514,7 +514,7 @@ class BaseWrapper(metaclass=WrapperRegister):
 
     @classmethod
     def from_dict(cls, **kwargs):
-        if isinstance(kwargs.get("config"), dict):
+        if isinstance(kwargs.get("config"), dict):  # pragma: no cover  # Ax should catch this
             kwargs["config"] = object_from_json(kwargs["config"])
             if isinstance(kwargs["config"], dict):
                 try:

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -11,6 +11,7 @@ import pathlib
 
 from ax import Trial
 from ax.core.types import TParameterization
+from ax.storage.json_store.decoder import object_from_json
 from ax.storage.json_store.encoder import object_to_json
 
 from boa.config import BOAConfig
@@ -513,6 +514,18 @@ class BaseWrapper(metaclass=WrapperRegister):
 
     @classmethod
     def from_dict(cls, **kwargs):
+        if isinstance(kwargs.get("config"), dict):
+            kwargs["config"] = object_from_json(kwargs["config"])
+            if isinstance(kwargs["config"], dict):
+                try:
+                    kwargs["config"] = BOAConfig(**kwargs["config"])
+                except TypeError as e:
+                    logger.warning(
+                        f"Could not deserialize wrapper config."
+                        f"\nLoading wrapper without config. You may not be able to resume new trials: "
+                        f"\n{e}"
+                    )
+
         return initialize_wrapper(
             wrapper=cls,
             post_init_attrs=dict(

--- a/boa/wrappers/script_wrapper.py
+++ b/boa/wrappers/script_wrapper.py
@@ -56,7 +56,9 @@ class ScriptWrapper(BaseWrapper):
         ----------
         trial : Trial
         """
-        self._run_subprocess_script_cmd_if_exists(trial, "write_configs")
+        param_names = {metric.name: metric.param_names for metric in self.config.objective.metrics}
+        kw = {"param_names": param_names} if param_names else {}
+        self._run_subprocess_script_cmd_if_exists(trial, "write_configs", **kw)
 
     def run_model(self, trial: Trial) -> None:
         """
@@ -172,7 +174,9 @@ class ScriptWrapper(BaseWrapper):
         :meth:`~boa.wrappers.script_wrapper.ScriptWrapper.run_model`
         # TODO add sphinx link to ax trial status
         """
-        self._run_subprocess_script_cmd_if_exists(trial, "set_trial_status")
+        param_names = {metric.name: metric.param_names for metric in self.config.objective.metrics}
+        kw = {"param_names": param_names} if param_names else {}
+        self._run_subprocess_script_cmd_if_exists(trial, "set_trial_status", **kw)
         data = self._read_subprocess_script_output(trial, file_names=["trial_status", "TrialStatus", *OUTPUT_FILES])
         if data is not None:
             trial_status_keys = [k for k in data.keys() if k.lower() == "trialstatus" or k.lower() == "trial_status"]

--- a/boa/wrappers/wrapper_utils.py
+++ b/boa/wrappers/wrapper_utils.py
@@ -390,7 +390,6 @@ def save_trial_data(trial: BaseTrial, trial_dir: pathlib.Path = None, experiment
     }
     for name, jsn in zip(["parameters", "trial", "data"], [parameters_jsn, trial_jsn, data]):
         file_path = trial_dir / f"{name}.json"
-        if not file_path.exists():
-            with open(file_path, "w+") as file:  # pragma: no cover
-                file.write(json.dumps(jsn, indent=4))
+        with open(file_path, "w+") as file:  # pragma: no cover
+            file.write(json.dumps(jsn, indent=4))
     return trial_dir

--- a/boa/wrappers/wrapper_utils.py
+++ b/boa/wrappers/wrapper_utils.py
@@ -144,10 +144,11 @@ def initialize_wrapper(
         try:
             module = _load_module_from_path(wrapper)
             WrapperCls: Type[BaseWrapper] = _load_attr_from_module(module, wrapper_name)
-        except Exception:
-            from boa.wrappers.script_wrapper import ScriptWrapper
-
-            WrapperCls = ScriptWrapper
+        except Exception as e:
+            raise AxError(
+                f"Could not load wrapper properly from {wrapper} with name {wrapper_name}."
+                "\nEnsure wrapper path and wrapper name are correct in config."
+            ) from e
     else:
         WrapperCls = wrapper
 

--- a/tests/1unit_tests/test_metrics.py
+++ b/tests/1unit_tests/test_metrics.py
@@ -13,7 +13,7 @@ from boa import (
 )
 
 
-class Wrapper(BaseWrapper):
+class WrapperForTestss(BaseWrapper):
     def __init__(self, *args, fetch_all=True, **kwargs):
         super().__init__(*args, **kwargs)
         self.fetch_all = fetch_all
@@ -45,7 +45,7 @@ class Wrapper(BaseWrapper):
                 }
 
 
-class WrapperPassThrough(Wrapper):
+class WrapperPassThrough(WrapperForTestss):
     def fetch_trial_data(self, trial, metric_properties, metric_name, *args, **kwargs):
         return trial.index
 
@@ -92,7 +92,7 @@ def test_load_metric_from_config(synth_config, generic_config):
 
 
 def test_metric_fetch_trial_data_works_with_wrapper_fetch_trial_data_and_test_sem_passing(moo_config, tmp_path):
-    controller = Controller(config=moo_config, wrapper=Wrapper, experiment_dir=tmp_path)
+    controller = Controller(config=moo_config, wrapper=WrapperForTestss, experiment_dir=tmp_path)
     controller.initialize_scheduler()
 
     scheduler = controller.scheduler
@@ -121,7 +121,7 @@ def test_metric_fetch_trial_data_works_with_wrapper_fetch_trial_all_data_and_tes
 ):
     orig_metrics = moo_config.objective.metrics
     moo_config.objective.metrics = orig_metrics[:1]
-    controller = Controller(config=moo_config, wrapper=Wrapper, experiment_dir=tmp_path)
+    controller = Controller(config=moo_config, wrapper=WrapperForTestss, experiment_dir=tmp_path)
     controller.initialize_scheduler()
 
     scheduler = controller.scheduler
@@ -134,7 +134,7 @@ def test_metric_fetch_trial_data_works_with_wrapper_fetch_trial_all_data_and_tes
 
 
 def test_metric_fetch_trial_data_works_with_wrapper_fetch_trial_data_single_and_test_sem_passing(moo_config, tmp_path):
-    controller = Controller(config=moo_config, wrapper=Wrapper, fetch_all=False, experiment_dir=tmp_path)
+    controller = Controller(config=moo_config, wrapper=WrapperForTestss, fetch_all=False, experiment_dir=tmp_path)
     controller.initialize_scheduler()
 
     scheduler = controller.scheduler
@@ -160,7 +160,7 @@ def test_metric_fetch_trial_data_works_with_wrapper_fetch_trial_data_single_and_
 
 
 def test_can_create_info_only_metrics(generic_config, tmp_path):
-    controller = Controller(config=generic_config, wrapper=Wrapper, experiment_dir=tmp_path)
+    controller = Controller(config=generic_config, wrapper=WrapperForTestss, experiment_dir=tmp_path)
     controller.initialize_scheduler()
 
     assert isinstance(controller.scheduler.experiment.optimization_config, OptimizationConfig)

--- a/tests/1unit_tests/test_wrapper.py
+++ b/tests/1unit_tests/test_wrapper.py
@@ -1,5 +1,26 @@
-from boa import BaseWrapper, BOAConfig
+import pytest
+
+from boa import BaseWrapper as BWrapper
+from boa import ModularMetric as MMetric
+from boa import WrappedJobRunner as WRunner
 
 
 def test_wrapper_instantiation(generic_config, tmp_path):
-    BaseWrapper(config=generic_config, experiment_dir=tmp_path)
+    BWrapper(config=generic_config, experiment_dir=tmp_path)
+
+
+def test_creating_wrapper_with_same_name_as_other_wrapper_from_diff_file_raises_val_error_and_metric_and_runner():
+    with pytest.raises(ValueError):
+
+        class BaseWrapper(BWrapper):
+            pass
+
+    with pytest.raises(ValueError):
+
+        class ModularMetric(MMetric):
+            pass
+
+    with pytest.raises(ValueError):
+
+        class WrappedJobRunner(WRunner):
+            pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,7 @@ def stand_alone_opt_package_run(request, tmp_path_factory, cd_to_root_and_back_s
             ],
             "script_options": {
                 "wrapper_path": str(wrapper_path),
+                "wrapper_name": "WrapperStandAlone",
                 "output_dir": str(temp_dir),
                 "exp_name": "test_experiment",
             },

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -84,8 +84,10 @@ def test_calling_command_line_r_test_scripts(r_scripts_run, request):
     assert len(scheduler.experiment.trials) == config.trials
 
     assert scheduler
-    if "r_package_streamlined" in str(wrapper.config_path):
-        assert "param_names" in load_jsonlike(get_trial_dir(wrapper.experiment_dir, 0) / "data.json")
+    if "r_package_full" in str(wrapper.config_path):
+        data = load_jsonlike(get_trial_dir(wrapper.experiment_dir, 0) / "data.json")
+        assert "param_names" in data
+        assert "metric_properties" in data
 
 
 @pytest.mark.skipif(not R_INSTALLED, reason="requires R to be installed")

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -27,7 +27,7 @@ except subprocess.CalledProcessError:
     R_INSTALLED = False
 
 
-class Wrapper(BaseWrapper):
+class WrapperDunderMain(BaseWrapper):
     def load_config(self, config_path, *args, **kwargs) -> BOAConfig:
         return BOAConfig(
             objective={"metrics": [{"name": "passthrough"}]},
@@ -101,5 +101,11 @@ def test_wrapper_with_custom_load_config():
     # But we override the failing config in our wrapper with a working one in a custom load_config
     wrapper_path = pathlib.Path(__file__)
     dunder_main.main(
-        split_shell_command(f"--config-path {config_path} --wrapper-path {wrapper_path} -td"), standalone_mode=False
+        split_shell_command(
+            f"--config-path {config_path}"
+            f" --wrapper-path {wrapper_path}"
+            f" --wrapper-name {WrapperDunderMain.__name__}"
+            " -td"
+        ),
+        standalone_mode=False,
     )

--- a/tests/scripts/other_langs/r_package_full/config.yaml
+++ b/tests/scripts/other_langs/r_package_full/config.yaml
@@ -2,6 +2,9 @@ objective: # can also use the key moo
     metrics:
         - name: metric
           metric: mean
+          param_names: [ x0, x1, x2, x3, x4, x5 ]
+          properties:
+              anything: "you want"
 generation_strategy:
     steps:
         - model: SOBOL

--- a/tests/scripts/other_langs/r_package_streamlined/config.yaml
+++ b/tests/scripts/other_langs/r_package_streamlined/config.yaml
@@ -1,7 +1,6 @@
 objective:
     metrics:
         - name: metric
-          param_names: [x0, x1, x2, x3, x4, x5]
 scheduler:
     n_trials: 15
 

--- a/tests/scripts/stand_alone_opt_package/stand_alone_pkg_config.yaml
+++ b/tests/scripts/stand_alone_opt_package/stand_alone_pkg_config.yaml
@@ -21,7 +21,6 @@ parameters:
     # test that a parameter that is just set likes this gets turned into a fixed parameter
     x1: 10
 
-# These are all defaults, so we don't need to specify them in this case
-#script_options:
-#    wrapper_path: ./wrapper.py
-#    wrapper_name: Wrapper
+script_options:
+#    wrapper_path: ./wrapper.py  # This is the default
+    wrapper_name: WrapperStandAlone  # This defaults to "Wrapper", but we change it here to whatever we called our Wrapper class

--- a/tests/scripts/stand_alone_opt_package/wrapper.py
+++ b/tests/scripts/stand_alone_opt_package/wrapper.py
@@ -6,7 +6,7 @@ from stand_alone_model_func import run_branin_from_trial
 import boa
 
 
-class Wrapper(boa.BaseWrapper):
+class WrapperStandAlone(boa.BaseWrapper):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.data = {}


### PR DESCRIPTION
Make wrappers automatically serialize much more often and easier Add in checks to no re-register Metrics, Runners, and Wrappers, since that overrides previous ones. This is also an error that raises to the user instead of a warning.
So users should have their Wrappers automatically register easier now, and get errors if it can't deserialize now. Also add ability to pass in wrapper-name to cli to override default or config wrapper-name if needed