### PR TITLE
Small qol updates

### DIFF
--- a/boa/config/config.py
+++ b/boa/config/config.py
@@ -262,6 +262,16 @@ class BOAObjective(_Utils):
         },
     )
 
+    def __init__(self, **config):
+        weights = config.pop("weights", None)
+        if weights:
+            if len(weights) != len(config["metrics"]):
+                raise TypeError("Number of weights must match number of metrics")
+            for i, weight in enumerate(weights):
+                config["metrics"][i]["weight"] = weight
+
+        self.__attrs_init__(**config)
+
 
 @define
 class BOAScriptOptions(_Utils):
@@ -369,6 +379,11 @@ class BOAScriptOptions(_Utils):
     )
 
     def __init__(self, **config):
+        if config.get("run_cmd"):
+            if config.get("run_model"):
+                raise TypeError("Must specify either run_cmd or run_model, not both")
+            config["run_model"] = config.pop("run_cmd")
+
         rel_to_config = config.get("rel_to_config", None)
         rel_to_launch = config.get("rel_to_launch", None)
         if rel_to_config and rel_to_launch:

--- a/boa/config/config.py
+++ b/boa/config/config.py
@@ -268,6 +268,8 @@ class BOAObjective(_Utils):
             if len(weights) != len(config["metrics"]):
                 raise TypeError("Number of weights must match number of metrics")
             for i, weight in enumerate(weights):
+                if config["metrics"][i].get("weight"):
+                    raise TypeError("Cannot specify weight in both objetive.weights and metric.weight")
                 config["metrics"][i]["weight"] = weight
 
         self.__attrs_init__(**config)

--- a/boa/plotting.py
+++ b/boa/plotting.py
@@ -16,7 +16,7 @@ import pandas as pd
 import panel as pn
 import plotly.graph_objs as go
 from ax.plot.contour import plot_contour_plotly
-from ax.plot.helper import get_range_parameters
+from ax.plot.helper import get_range_parameters_from_list
 from ax.plot.pareto_frontier import plot_pareto_frontier as ax_plot_pareto_frontier
 from ax.plot.pareto_utils import compute_posterior_pareto_frontier
 from ax.plot.slice import interact_slice_plotly
@@ -48,6 +48,7 @@ __all__ = [
 def _maybe_load_scheduler(scheduler: SchedulerOrPath):
     if isinstance(scheduler, PathLike_tup):
         scheduler = scheduler_from_json_file(scheduler)
+        scheduler.generation_strategy._fit_or_update_current_model(data=scheduler.experiment.fetch_data())
     return scheduler
 
 
@@ -173,8 +174,7 @@ def plot_contours(
 
     if not metric_names:
         metric_names = list(scheduler.experiment.metrics.keys())
-
-    range_parameters = get_range_parameters(model, min_num_values=5)
+    range_parameters = get_range_parameters_from_list(list(scheduler.experiment.parameters.values()), min_num_values=5)
     param_names1 = [parameter.name for i, parameter in enumerate(range_parameters) if i != 1]
     param_names2 = [parameter.name for i, parameter in enumerate(range_parameters) if i != 0]
 

--- a/boa/storage.py
+++ b/boa/storage.py
@@ -217,10 +217,7 @@ def scheduler_from_json_snapshot(
         generation_strategy_json=serialized_generation_strategy, experiment=experiment
     )
 
-    generation_strategy._fit_or_update_current_model(data=experiment.fetch_data())
-
     scheduler = Scheduler(generation_strategy=generation_strategy, experiment=experiment, options=options, **kwargs)
-    scheduler._experiment = experiment
     if wrapper:
         if isinstance(scheduler.experiment.runner, WrappedJobRunner):
             scheduler.experiment.runner.wrapper = wrapper

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -84,6 +84,11 @@ class BaseWrapper(metaclass=WrapperRegister):
             self._metric_names = []
 
     @property
+    def metric_params(self) -> dict:
+        """dictionary of metric name to list of parameter names associated with each metric"""
+        return {metric.name: metric.param_names for metric in self.config.objective.metrics}
+
+    @property
     def config(self) -> BOAConfig:
         return self._config
 
@@ -102,6 +107,7 @@ class BaseWrapper(metaclass=WrapperRegister):
                 metric_propertis[name] = metric.properties
 
         self._metric_properties = metric_propertis
+        # TODO we could set _metric_names here
 
     @property
     def experiment_dir(self):

--- a/tests/1unit_tests/test_config_normalization.py
+++ b/tests/1unit_tests/test_config_normalization.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from boa import BOAConfig
+
 
 def test_wpr_params_to_boa(denormed_param_parse_config):
     # parameter_keys = denormed_param_parse_config.parameter_keys
@@ -29,3 +31,27 @@ def test_boa_params_to_wpr(denormed_param_parse_config):
 
     d = {k: v for k, v in config.orig_config.items() if k in [keys[0] for keys in config.parameter_keys]}
     TestCase().assertDictEqual(d, orig_params)
+
+
+def test_config_run_cmd_sets_to_run_model():
+    config = {
+        "objective": {"metrics": [{"name": "a"}]},
+        "parameters": {"x": 10},
+        "n_trials": 1,
+        "script_options": {"run_cmd": "some command"},
+    }
+    c = BOAConfig(**config)
+    assert c.script_options.run_model == "some command"
+
+
+def test_config_weights_can_be_set_on_obj_passed_to_metrics():
+    weights = [1, 2]
+    config = {
+        "objective": {"metrics": [{"name": "a"}, {"name": "b"}], "weights": weights},
+        "parameters": {"x": 10},
+        "n_trials": 1,
+        "script_options": {"run_cmd": "some command"},
+    }
+    c = BOAConfig(**config)
+    for metric, weight in zip(c.objective.metrics, weights):
+        assert metric.weight == weight

--- a/tests/1unit_tests/test_config_normalization.py
+++ b/tests/1unit_tests/test_config_normalization.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+import pytest
+
 from boa import BOAConfig
 
 
@@ -44,6 +46,20 @@ def test_config_run_cmd_sets_to_run_model():
     assert c.script_options.run_model == "some command"
 
 
+def test_config_run_cmd_and_run_model_error():
+    config = {
+        "objective": {"metrics": [{"name": "a"}]},
+        "parameters": {"x": 10},
+        "n_trials": 1,
+        "script_options": {
+            "run_cmd": "some command",
+            "run_model": "some command",
+        },
+    }
+    with pytest.raises(TypeError):
+        BOAConfig(**config)
+
+
 def test_config_weights_can_be_set_on_obj_passed_to_metrics():
     weights = [1, 2]
     config = {
@@ -55,3 +71,15 @@ def test_config_weights_can_be_set_on_obj_passed_to_metrics():
     c = BOAConfig(**config)
     for metric, weight in zip(c.objective.metrics, weights):
         assert metric.weight == weight
+
+
+def test_config_obj_weights_and_metric_weights_error():
+    weights = [1, 2]
+    config = {
+        "objective": {"metrics": [{"name": "a", "weight": 1}, {"name": "b", "weight": 2}], "weights": weights},
+        "parameters": {"x": 10},
+        "n_trials": 1,
+        "script_options": {"run_cmd": "some command"},
+    }
+    with pytest.raises(TypeError):
+        BOAConfig(**config)


### PR DESCRIPTION
- [Allow run_model to alias to run_cmd, and allow weights to be objetive…](https://github.com/madeline-scyphers/boa/commit/f08d17c120c36c9efa9f63e7dc014022ac1bdb88) 
  … argument as well as metrics argument
- [Add checks for double listing weights and run_cmd/run_model](https://github.com/madeline-scyphers/boa/commit/880a248e7203d6d1a6d0348441a5e3011e66c551)
- [Move generation_strat model reinit to plotting](https://github.com/madeline-scyphers/boa/commit/e406bb37ca45883e2993696e98ca897ce0c72c14) 
  b/c that is when you need it reinit without running trials
  And it can be expensive to do it with no reason on things like saasbo
- [Add metric_params property to wrappers](https://github.com/madeline-scyphers/boa/commit/cfd6d40910ec87c19ef2c120bb5b341f11aa476e)