### PR TITLE
Change config (de)serialize to be to and from a dict and wrapper to handle the rest

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: invoke tests --options '-s -v --cov=boa --cov-branch --cov-report=xml'
+        run: invoke tests --options '-v -s --cov=boa --cov-branch --cov-report=xml'
 
       - name: Upload coverage to Codecov
         if: startsWith(matrix.os, 'ubuntu')

--- a/boa/__init__.py
+++ b/boa/__init__.py
@@ -48,9 +48,9 @@ import warnings  # noqa
 # In a future version of pandas,
 # a length 1 tuple will be returned when iterating over a groupby with a grouper equal to a list of length 1.
 warnings.filterwarnings("ignore", category=FutureWarning, module="ax.core.observation")
-# In AX, this error happens, refering to their own calling of their own function
-#  FYI: The default behavior of `get_pareto_frontier_and_configs` when `transform_outcomes_and_configs`
-#  is not specified has changed.
-warnings.filterwarnings("ignore", category=UserWarning, module="ax.modelbridge.modelbridge_utils", lineno=852)
+# In AX, this error happens, referring to their own calling of their own function
+warnings.filterwarnings(
+    "ignore", message="You passed `transform_outcomes_and_configs=False`.*", module="ax.modelbridge.modelbridge_utils"
+)
 
 del warnings

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -34,6 +34,8 @@ HEADER_BAR = """
 LOG_INFO = (
     """BOA Experiment Run
 Output Experiment Dir: {exp_dir}
+Scheduler File Path: {scheduler_path}
+Optimization CSV File Path: {opt_csv_path}
 Start Time: {start_time}
 Version: """
     + f"{VERSION}"
@@ -168,13 +170,17 @@ class Controller:
         """
         start = time.time()
         start_tm = get_dt_now_as_str()
+        scheduler = scheduler or self.scheduler
         self.logger.info(
             f"\n{HEADER_BAR}"
-            f"\n\n{LOG_INFO.format(exp_dir=self.wrapper.experiment_dir, start_time=start_tm)}"
+            f"""\n\n{LOG_INFO.format(
+                exp_dir=self.wrapper.experiment_dir,
+                start_time=start_tm,
+                scheduler_path=scheduler.scheduler_filepath,
+                opt_csv_path=scheduler.opt_filepath)}"""
             f"\n{HEADER_BAR}"
         )
 
-        scheduler = scheduler or self.scheduler
         wrapper = wrapper or self.wrapper
         if not scheduler or not wrapper:
             raise ValueError("Scheduler and wrapper must be defined, or setup in setup method!")
@@ -192,7 +198,11 @@ class Controller:
             self.logger.info(
                 f"\n{HEADER_BAR}"
                 f"\n{final_msg}"
-                f"\n{LOG_INFO.format(exp_dir=self.wrapper.experiment_dir, start_time=start_tm)}"
+                f"""\n{LOG_INFO.format(
+                    exp_dir=self.wrapper.experiment_dir,
+                    start_time=start_tm,
+                    scheduler_path=scheduler.scheduler_filepath,
+                    opt_csv_path=scheduler.opt_filepath)}"""
                 f"\nEnd Time: {get_dt_now_as_str()}"
                 f"\nTotal Run Time: {time.time() - start}"
                 "\n"

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -171,17 +171,17 @@ class Controller:
         start = time.time()
         start_tm = get_dt_now_as_str()
         scheduler = scheduler or self.scheduler
+        wrapper = wrapper or self.wrapper
         self.logger.info(
             f"\n{HEADER_BAR}"
             f"""\n\n{LOG_INFO.format(
-                exp_dir=self.wrapper.experiment_dir,
+                exp_dir=wrapper.experiment_dir,
                 start_time=start_tm,
-                scheduler_path=scheduler.scheduler_filepath,
-                opt_csv_path=scheduler.opt_filepath)}"""
+                scheduler_path=Path(wrapper.experiment_dir) / scheduler.scheduler_filepath,
+                opt_csv_path=Path(wrapper.experiment_dir) / scheduler.opt_filepath)}"""
             f"\n{HEADER_BAR}"
         )
 
-        wrapper = wrapper or self.wrapper
         if not scheduler or not wrapper:
             raise ValueError("Scheduler and wrapper must be defined, or setup in setup method!")
 
@@ -201,8 +201,8 @@ class Controller:
                 f"""\n{LOG_INFO.format(
                     exp_dir=self.wrapper.experiment_dir,
                     start_time=start_tm,
-                    scheduler_path=scheduler.scheduler_filepath,
-                    opt_csv_path=scheduler.opt_filepath)}"""
+                    scheduler_path=Path(wrapper.experiment_dir) / scheduler.scheduler_filepath,
+                    opt_csv_path=Path(wrapper.experiment_dir) / scheduler.opt_filepath)}"""
                 f"\nEnd Time: {get_dt_now_as_str()}"
                 f"\nTotal Run Time: {time.time() - start}"
                 "\n"

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -96,26 +96,9 @@ class Controller:
         scheduler = scheduler_from_json_file(scheduler_path, **kwargs)
         wrapper = scheduler.experiment.runner.wrapper
 
-        # experiment dir doesn't exist anymore, etierh bc it was deleted or bc we changed computers
-        kw = {}
-        if not wrapper.experiment_dir or (
-            isinstance(wrapper.experiment_dir, Path) and not wrapper.experiment_dir.exists()
-        ):
-            kw["experiment_dir"] = Path(scheduler_path).parent
-            if wrapper.experiment_dir:  # copy old name over
-
-                kw["experiment_name"] = Path(wrapper.experiment_dir).name
-                kw["append_timestamp"] = False
-            wrapper.mk_experiment_dir(**kw)
         inst = cls(wrapper=wrapper, working_dir=working_dir, **kwargs)
-        inst.logger.info(f"Resuming optimization from scheduler path{scheduler_path}")
-        if "experiment_dir" in kw:
-            inst.logger.info(
-                f"Making new experiment dir here: {wrapper.experiment_dir}."
-                f"\nOld experiment directory not found. "
-                f"\nMost likely because it was deleted or because of reloading on a different computer than"
-                f" originally ran on."
-            )
+        inst.logger.info(f"Resuming optimization from scheduler path: {scheduler_path}")
+
         inst.scheduler = scheduler
         inst.experiment = scheduler.experiment
         return inst

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -13,7 +13,6 @@ import time
 from pathlib import Path
 from typing import Type
 
-import ruamel.yaml as yaml
 from ax import Experiment
 from ax.service.utils.report_utils import exp_to_df
 
@@ -25,6 +24,7 @@ from boa.logger import get_logger
 from boa.runner import WrappedJobRunner
 from boa.scheduler import Scheduler
 from boa.storage import scheduler_from_json_file
+from boa.utils import yaml_dump
 from boa.wrappers.base_wrapper import BaseWrapper
 from boa.wrappers.wrapper_utils import get_dt_now_as_str, initialize_wrapper
 
@@ -79,9 +79,7 @@ class Controller:
             # Copy the experiment config to the experiment directory
             shutil.copyfile(wrapper.config_path, wrapper.experiment_dir / Path(config_path).name)
         else:
-            with open(wrapper.experiment_dir / "config.yaml", "w") as f:
-                # Write out config as yaml since we don't know what file format it came from
-                yaml.dump(wrapper.config, f)
+            yaml_dump(wrapper.config, wrapper.experiment_dir / "config.yaml")
 
         self.wrapper = wrapper
         self.config = self.wrapper.config

--- a/boa/registry.py
+++ b/boa/registry.py
@@ -1,23 +1,9 @@
-import attrs
 from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
-
-
-def attrs_to_dict(inst):
-    """Convert Ax runner to a dictionary."""
-    d = attrs.asdict(
-        inst,
-        filter=lambda attr, value: True
-        if not inst._filtered_dict_fields
-        else attr.name not in inst._filtered_dict_fields,
-    )
-    d["__type"] = inst.__class__.__name__
-    return d
 
 
 def config_to_dict(inst):
     """Convert Ax runner to a dictionary."""
     d = {k: v for k, v in inst.orig_config.items()}
-    d["__type"] = inst.__class__.__name__
     return d
 
 
@@ -27,5 +13,5 @@ def _add_common_encodes_and_decodes():
     from boa.config import BOAConfig, MetricType
 
     CORE_ENCODER_REGISTRY[BOAConfig] = config_to_dict
-    CORE_DECODER_REGISTRY[BOAConfig.__name__] = BOAConfig
+    # CORE_DECODER_REGISTRY[BOAConfig.__name__] = BOAConfig
     CORE_DECODER_REGISTRY[MetricType.__name__] = MetricType

--- a/boa/scheduler.py
+++ b/boa/scheduler.py
@@ -8,6 +8,7 @@ from ax.service.scheduler import Scheduler as AxScheduler
 
 from boa.logger import get_logger
 from boa.runner import WrappedJobRunner
+from boa.wrappers.base_wrapper import BaseWrapper
 
 logger = get_logger()
 
@@ -16,6 +17,10 @@ class Scheduler(AxScheduler):
     runner: WrappedJobRunner
     scheduler_filepath: str = "scheduler.json"
     opt_filepath: str = "optimization.csv"
+
+    @property
+    def wrapper(self) -> BaseWrapper:
+        return self.runner.wrapper
 
     def report_results(self, force_refit: bool = False):
         """

--- a/boa/scheduler.py
+++ b/boa/scheduler.py
@@ -14,6 +14,8 @@ logger = get_logger()
 
 class Scheduler(AxScheduler):
     runner: WrappedJobRunner
+    scheduler_filepath: str = "scheduler.json"
+    opt_filepath: str = "optimization.csv"
 
     def report_results(self, force_refit: bool = False):
         """
@@ -213,6 +215,12 @@ class Scheduler(AxScheduler):
         from boa.storage import dump_scheduler_data
 
         try:
-            dump_scheduler_data(scheduler=self, dir_=self.runner.wrapper.experiment_dir, **kwargs)
+            dump_scheduler_data(
+                scheduler=self,
+                dir_=self.runner.wrapper.experiment_dir,
+                scheduler_filepath=self.scheduler_filepath,
+                opt_filepath=self.opt_filepath,
+                **kwargs,
+            )
         except Exception as e:
             logger.exception("failed to save scheduler to json! Reason: %s" % repr(e))

--- a/boa/storage.py
+++ b/boa/storage.py
@@ -9,6 +9,7 @@ stop and restart.
 """
 
 import json
+import logging
 import pathlib
 from copy import deepcopy
 from dataclasses import asdict
@@ -196,6 +197,13 @@ def scheduler_from_json_snapshot(
             )
         if not exp_dir or not pathlib.Path(exp_dir).exists():
             wrapper_dict["experiment_dir"] = str(pathlib.Path(filepath).parent)
+            logger = get_logger(filename=str(pathlib.Path(wrapper_dict["experiment_dir"]) / "optimization.log"))
+            for handler in logger.handlers:
+                if isinstance(handler, logging.FileHandler):
+                    if not pathlib.Path(handler.baseFilename).exists():
+                        logger.removeHandler(handler)
+            # setup file handler on ax logger too
+            get_logger("ax", filename=str(pathlib.Path(wrapper_dict["experiment_dir"]) / "optimization.log"))
             logger.info(
                 f"Making new experiment dir here: {wrapper_dict['experiment_dir']}."
                 f"\nOld experiment directory not found. "

--- a/boa/storage.py
+++ b/boa/storage.py
@@ -190,7 +190,7 @@ def scheduler_from_json_snapshot(
 
         if exp_dir:
             exp_dir = object_from_json(
-                exp_dir,
+                deepcopy(exp_dir),
                 decoder_registry=decoder_registry,
                 class_decoder_registry=class_decoder_registry,
             )
@@ -203,10 +203,9 @@ def scheduler_from_json_snapshot(
                 f" originally ran on."
             )
 
-        wd = deepcopy(wrapper_dict)
         try:
             wrapper = object_from_json(
-                deepcopy(wd),
+                deepcopy(wrapper_dict),
                 decoder_registry=decoder_registry,
                 class_decoder_registry=class_decoder_registry,
             )

--- a/boa/storage.py
+++ b/boa/storage.py
@@ -239,18 +239,18 @@ def recursive_deserialize(obj, **kwargs):
     return obj
 
 
-def exp_opt_to_csv(experiment, opt_path: PathLike = "optimization.csv", dir_: PathLike = None, **kwargs):
+def exp_opt_to_csv(experiment, opt_filepath: PathLike = "optimization.csv", dir_: PathLike = None, **kwargs):
     if dir_:
-        opt_path = pathlib.Path(dir_) / opt_path
+        opt_filepath = pathlib.Path(dir_) / opt_filepath
     df = exp_to_df(experiment)
-    df.to_csv(path_or_buf=opt_path, index=False, **kwargs)
-    logger.info(f"Saved optimization parametrization and objective to `{opt_path}`.")
+    df.to_csv(path_or_buf=opt_filepath, index=False, **kwargs)
+    logger.info(f"Saved optimization parametrization and objective to `{opt_filepath}`.")
 
 
 def scheduler_opt_to_csv(scheduler, **kwargs):
     return exp_opt_to_csv(scheduler.experiment, **kwargs)
 
 
-def dump_scheduler_data(scheduler, **kwargs):
-    scheduler_to_json_file(scheduler, **kwargs)
-    scheduler_opt_to_csv(scheduler, **kwargs)
+def dump_scheduler_data(scheduler, scheduler_filepath, opt_filepath, **kwargs):
+    scheduler_to_json_file(scheduler, scheduler_filepath=scheduler_filepath, **kwargs)
+    scheduler_opt_to_csv(scheduler, opt_filepath=opt_filepath, **kwargs)

--- a/boa/utils.py
+++ b/boa/utils.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Type, Union
 
 import torch
+from ruamel.yaml import YAML
 
 from boa.definitions import PathLike
 
@@ -286,3 +287,9 @@ class StrEnum(str, Enum):  # pragma: no cover  # copied from python 3.11
     @classmethod
     def from_str_or_enum(cls, value: Union[str, "StrEnum"]) -> "StrEnum":
         return cls(value)
+
+
+def yaml_dump(data: dict, path: PathLike) -> None:
+    yaml = YAML(typ="unsafe", pure=True)
+    with open(path, "w") as file:
+        yaml.dump(data, file)

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -559,11 +559,12 @@ class BaseWrapper(metaclass=WrapperRegister):
 
     @classmethod
     def from_dict(cls, **kwargs):
-        config_path = None
-        if "config_path" in kwargs:
-            config_path = pathlib.Path(kwargs["config_path"])
+        config_path = kwargs.pop("config_path", None)
+        config_path = pathlib.Path(config_path) if config_path else None
+        if config_path:
+            config_path = pathlib.Path(config_path)
             if not config_path.exists() and "experiment_dir" in kwargs:
-                config_path = pathlib.Path(kwargs["experiment_dir"]) / pathlib.Path(kwargs["config_path"]).name
+                config_path = pathlib.Path(kwargs["experiment_dir"]) / config_path.name
         if not config_path or not config_path.exists():
             if "experiment_dir" in kwargs:
                 configs = pathlib.Path(kwargs["experiment_dir"]).glob("config.*")

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -584,9 +584,11 @@ class BaseWrapper(metaclass=WrapperRegister):
                     exp_dir = pathlib.Path(kwargs["experiment_dir"])
                 else:
                     exp_dir = pathlib.Path.cwd()
-                with open(exp_dir / "temp_config.yaml", "w") as f:
+                config_path = exp_dir / "temp_config.yaml"
+                with open(config_path, "w") as f:
                     # Write out config as yaml since we don't know what file format it came from
                     yaml.dump(kwargs["config"], f)
+                kwargs["config_path"] = config_path
                 logger.warning(
                     f"No config path found, writing out config to {exp_dir / 'temp_config.yaml'}"
                     " and using that as config_path"

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -39,7 +39,7 @@ class BaseWrapper(metaclass=WrapperRegister):
     kwargs
     """
 
-    def __init__(self, config_path: PathLike = None, config: BOAConfig = None, setup=True, *args, **kwargs):
+    def __init__(self, config_path: PathLike = None, config: dict | BOAConfig = None, setup=True, *args, **kwargs):
         self.config_path = config_path
         self._experiment_dir = None
         self._working_dir = None

--- a/boa/wrappers/base_wrapper.py
+++ b/boa/wrappers/base_wrapper.py
@@ -11,6 +11,7 @@ import copy
 import pathlib
 from typing import Optional
 
+import ruamel.yaml as yaml
 from ax import Trial
 from ax.core.types import TParameterization
 from ax.storage.json_store.encoder import object_to_json
@@ -577,6 +578,21 @@ class BaseWrapper(metaclass=WrapperRegister):
                             break
         if config_path and config_path.exists():
             kwargs["config_path"] = config_path
+        else:
+            if "config" in kwargs:
+                if "experiment_dir" in kwargs:
+                    exp_dir = pathlib.Path(kwargs["experiment_dir"])
+                else:
+                    exp_dir = pathlib.Path.cwd()
+                with open(exp_dir / "temp_config.yaml", "w") as f:
+                    # Write out config as yaml since we don't know what file format it came from
+                    yaml.dump(kwargs["config"], f)
+                logger.warning(
+                    f"No config path found, writing out config to {exp_dir / 'temp_config.yaml'}"
+                    " and using that as config_path"
+                )
+            else:
+                logger.warning(f"No config path found, and no config passed in! No config to pass to wrapper {cls}")
 
         return initialize_wrapper(
             wrapper=cls,

--- a/tasks.py
+++ b/tasks.py
@@ -88,7 +88,7 @@ Running pytest the test framework
 =================================
 """
     )
-    command.run(f"python -m pytest {options} {dir_}", echo=True, pty=POSIX)
+    command.run(f"python -m pytest -v {options} {dir_}", echo=True, pty=POSIX)
 
 
 @task(aliases=["tests"])

--- a/tests/integration_tests/test_storage.py
+++ b/tests/integration_tests/test_storage.py
@@ -120,6 +120,7 @@ def test_config_param_parse_with_custom_wrapper_load_config(denormed_custom_wrap
         assert key["name"] in names
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows doesn't support moving files that are open")
 def test_custom_wrapper_load_config_reload_from_moved_files(denormed_custom_wrapper_run, tmp_path, caplog):
     scheduler = denormed_custom_wrapper_run
     output_dir = tmp_path / "output_dir"

--- a/tests/integration_tests/test_storage.py
+++ b/tests/integration_tests/test_storage.py
@@ -35,8 +35,7 @@ TEST_DIR = ROOT / "tests"
 
 
 class WrapperConfigNormalization(BaseWrapper):
-    def load_config(self, config_path, *args, **kwargs) -> BOAConfig:
-        config = load_jsonlike(config_path)
+    def load_config(self, raw_config, *args, **kwargs) -> BOAConfig:
         parameter_keys = [
             ["params", "a"],
             ["params", "b"],
@@ -44,7 +43,11 @@ class WrapperConfigNormalization(BaseWrapper):
             ["params2", 0, "a"],
             ["params2", 1, "b"],
         ]
-        return BOAConfig(parameter_keys=parameter_keys, **config)
+        assert "dummy_key" in raw_config["params_a"]["x1"]
+        assert "dummy_key" in raw_config["params_a"]["x2"]
+        raw_config["params_a"]["x1"].pop("dummy_key")
+        raw_config["params_a"]["x2"].pop("dummy_key")
+        return BOAConfig(parameter_keys=parameter_keys, **raw_config)
 
     def run_model(self, trial) -> None:
         """"""
@@ -88,7 +91,7 @@ def test_save_load_config(config, request):
         decoder_registry=CORE_DECODER_REGISTRY,
         class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
     )
-    assert config == c
+    assert config == BOAConfig(**c)
 
 
 def test_config_param_parse_with_custom_wrapper_load_config(denormed_custom_wrapper_config_path, tmp_path):

--- a/tests/integration_tests/test_storage.py
+++ b/tests/integration_tests/test_storage.py
@@ -23,7 +23,6 @@ from boa import (
     get_dictionary_from_callable,
     get_scheduler,
     instantiate_search_space_from_json,
-    load_jsonlike,
     scheduler_from_json_file,
     scheduler_to_json_file,
     split_shell_command,

--- a/tests/test_configs/test_config_param_parse_with_wrapper_load.yaml
+++ b/tests/test_configs/test_config_param_parse_with_wrapper_load.yaml
@@ -24,10 +24,12 @@ params:
 
 params_a:
     x1:
+        dummy_key: dummy_value
         type: range
         bounds: [ 0, 1 ]
         value_type: float
     x2:
+        dummy_key: dummy_value
         type: fixed
         value: 0.5
         value_type: float


### PR DESCRIPTION
config only will be deserialized as a dict, let the wrapper class in `load_config` handle loading to `BOAConfig`. This will let the config classes be not normalized right, and the wrpaper correct that properly still.