### PR TITLE
Bugfix/scriptwrapper popen blocking

### DIFF
--- a/boa/logger.py
+++ b/boa/logger.py
@@ -1,11 +1,14 @@
 import logging
 import logging.config
 import logging.handlers
+import multiprocessing
 
 from boa.definitions import PathLike
 
 DEFAULT_LOG_LEVEL: int = logging.INFO
 ROOT_LOGGER_NAME = "boa"
+
+queue = multiprocessing.Manager().Queue()
 
 
 def get_logger(name: str = ROOT_LOGGER_NAME, level: int = DEFAULT_LOG_LEVEL, filename=None) -> logging.Logger:
@@ -45,7 +48,7 @@ def set_handlers(logger, level=DEFAULT_LOG_LEVEL, filename=None):
 
 
 def get_formatter():
-    fmt = "[%(levelname)s %(asctime)s %(processName)s] %(name)s: %(message)s"
+    fmt = "[%(levelname)s %(asctime)s %(processName)s %(threadName)s] %(name)s: %(message)s"
     formatter = logging.Formatter(fmt=fmt)
     return formatter
 

--- a/boa/runner.py
+++ b/boa/runner.py
@@ -33,6 +33,9 @@ class WrappedJobRunner(Runner, metaclass=RunnerRegister):
     def run(self, trial: Trial) -> Dict[str, Any]:
         """Deploys a trial based on custom runner subclass implementation.
 
+        Add a logging queue handler to the boa and ax root loggers to capture logs from the
+        wrapper.
+
         Args:
             trial: The trial to deploy.
 
@@ -41,8 +44,9 @@ class WrappedJobRunner(Runner, metaclass=RunnerRegister):
         """
         qh = logging.handlers.QueueHandler(queue)
         logger = logging.getLogger()
-        logger.setLevel(logging.DEBUG)
         logger.addHandler(qh)
+        ax_logger = logging.getLogger("ax")
+        ax_logger.addHandler(qh)
 
         if not isinstance(trial, Trial):
             raise ValueError("This runner only handles `Trial`.")

--- a/boa/runner.py
+++ b/boa/runner.py
@@ -8,6 +8,7 @@ Runner that calls your :mod:`.wrappers` to run your model and poll the trial sta
 """
 
 import concurrent.futures
+import logging
 from collections import defaultdict
 from typing import Any, Dict, Iterable, Set
 
@@ -15,7 +16,7 @@ from ax.core.base_trial import TrialStatus
 from ax.core.runner import Runner
 from ax.core.trial import Trial
 
-from boa.logger import get_logger
+from boa.logger import get_logger, queue
 from boa.metaclasses import RunnerRegister
 from boa.utils import serialize_init_args
 from boa.wrappers.base_wrapper import BaseWrapper
@@ -38,6 +39,11 @@ class WrappedJobRunner(Runner, metaclass=RunnerRegister):
         Returns:
             Dict of run metadata from the deployment process.
         """
+        qh = logging.handlers.QueueHandler(queue)
+        logger = logging.getLogger()
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(qh)
+
         if not isinstance(trial, Trial):
             raise ValueError("This runner only handles `Trial`.")
 

--- a/boa/scheduler.py
+++ b/boa/scheduler.py
@@ -74,9 +74,12 @@ class Scheduler(AxScheduler):
         except Exception as e:  # pragma: no cover
             best_trial_str = ""
             logger.exception(e)
+        trials_ls = [str(t.index) for t in self.running_trials]
+        if len(trials_ls) == 1:
+            trials_ls = trials_ls[0]
         update = (
             f"Trials so far: {len(self.experiment.trials)}"
-            f"\nRunning trials: {', '.join(str(t.index) for t in self.running_trials)}"
+            f"\nRunning trials: {trials_ls}"
             f"\nWill Produce next trials from generation step: {self.generation_strategy.current_step.model_name}"
             f"{best_trial_str}"
         )

--- a/boa/wrappers/script_wrapper.py
+++ b/boa/wrappers/script_wrapper.py
@@ -337,7 +337,11 @@ class ScriptWrapper(BaseWrapper):
         return None
 
 
-def subprocess_output(p, trial):
+def subprocess_output(p: subprocess.Popen, trial: Trial):
+    """
+    log the output of a subprocess `p` to the logger
+    and mark the trial as failed if the subprocess exits with a non-zero exit code
+    """
     while (exit_code := p.poll()) is None:
         for line in p.stdout:
             logger.info(line.strip())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,42 +208,28 @@ def moo_main_run(tmp_path_factory, cd_to_root_and_back_session):
 
 
 @pytest.fixture(scope="session")
-def stand_alone_opt_package_run(request, tmp_path_factory, cd_to_root_and_back_session):
-    # parametrize the test to pass in script options in config as relative and absolute paths
-    if getattr(request, "param", None) == "absolute":
-        temp_dir = tmp_path_factory.mktemp("temp_dir")
-        wrapper_path = (TEST_DIR / "scripts/stand_alone_opt_package/wrapper.py").resolve()
-        config = {
-            "objective": {"metrics": [{"metric": "mean", "name": "Mean"}, {"metric": "RMSE", "info_only": True}]},
-            "generation_strategy": {
-                "steps": [{"model": "SOBOL", "num_trials": 2}, {"model": "GPEI", "num_trials": -1}]
-            },
-            "scheduler": {"total_trials": 5},
-            "parameters": [
-                {"bounds": [-5.0, 10.0], "name": "x0", "type": "range"},
-                {"bounds": [0.0, 15.0], "name": "x1", "type": "range"},
-            ],
-            "script_options": {
-                "wrapper_path": str(wrapper_path),
-                "wrapper_name": "WrapperStandAlone",
-                "output_dir": str(temp_dir),
-                "exp_name": "test_experiment",
-            },
-        }
-        config_path = temp_dir / "config.yaml"
-        with open(Path(config_path), "w") as file:
-            json.dump(config, file)
-            args = f"--config-path {config_path}"
-    else:
-        config_path = TEST_DIR / "scripts/stand_alone_opt_package/stand_alone_pkg_config.yaml"
-        args = f"--config-path {config_path} -td"
-
+def stand_alone_opt_package_run(tmp_path_factory, cd_to_root_and_back_session):
+    config_path = TEST_DIR / "scripts/stand_alone_opt_package/stand_alone_pkg_config.yaml"
+    args = f"--config-path {config_path} -td"
     yield dunder_main.main(split_shell_command(args), standalone_mode=False)
 
 
 @pytest.fixture(scope="session")
-def r_scripts_run(request, tmp_path_factory, cd_to_root_and_back_session):
-    sub_dir = request.param
-    config_path = TEST_DIR / f"scripts/other_langs/r_package_{sub_dir}/config.yaml"
+def r_full(tmp_path_factory, cd_to_root_and_back_session):
+    config_path = TEST_DIR / f"scripts/other_langs/r_package_full/config.yaml"
+
+    yield dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)
+
+
+@pytest.fixture(scope="session")
+def r_light(tmp_path_factory, cd_to_root_and_back_session):
+    config_path = TEST_DIR / f"scripts/other_langs/r_package_light/config.yaml"
+
+    yield dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)
+
+
+@pytest.fixture(scope="session")
+def r_streamlined(tmp_path_factory, cd_to_root_and_back_session):
+    config_path = TEST_DIR / f"scripts/other_langs/r_package_streamlined/config.yaml"
 
     yield dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -110,3 +110,22 @@ def test_wrapper_with_custom_load_config():
         ),
         standalone_mode=False,
     )
+
+
+def test_parallelism(r_light, caplog):
+    log = []
+    for record in caplog.get_records("setup"):
+        line = record.message
+        if "R script started running." in line or "R script finished running." in line:
+            log.append(line)
+    found_parallelism = False
+    for line in range(len(log) - 1):
+        if "R script started running." in log[line] and "R script started running." in log[line + 1]:
+            found_parallelism = True
+    assert found_parallelism
+
+
+def test_non_zero_exit_code_fails_trial():
+    with pytest.raises(FailureRateExceededError):
+        config_path = ROOT / "tests" / f"scripts/other_langs/r_failure_exit_code/config.yaml"
+        dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -73,18 +73,17 @@ def test_calling_command_line_test_script_doesnt_error_out_and_produces_correct_
 # or parametrize the test to use the streamlined version (doesn't use trial_status.json, only use output.json)
 @pytest.mark.parametrize(
     "r_scripts_run",
-    ["full", "light", "streamlined"],
-    indirect=True,
+    ["r_full", "r_light", "r_streamlined"],
 )
 @pytest.mark.skipif(not R_INSTALLED, reason="requires R to be installed")
 def test_calling_command_line_r_test_scripts(r_scripts_run, request):
-    scheduler = r_scripts_run
+    scheduler = request.getfixturevalue(r_scripts_run)
     wrapper = scheduler.experiment.runner.wrapper
     config = wrapper.config
     assert len(scheduler.experiment.trials) == config.trials
 
     assert scheduler
-    if "r_package_full" in str(wrapper.config_path):
+    if "r_full" == r_scripts_run:
         data = load_jsonlike(get_trial_dir(wrapper.experiment_dir, 0) / "data.json")
         assert "param_names" in data
         assert "metric_properties" in data

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -113,11 +113,12 @@ def test_wrapper_with_custom_load_config():
 
 
 def test_parallelism(r_light, caplog):
-    log = []
-    for record in caplog.get_records("setup"):
-        line = record.message
-        if "R script started running." in line or "R script finished running." in line:
-            log.append(line)
+    scheduler = r_light
+    log_f = scheduler.wrapper.experiment_dir / "optimization.log"
+    with open(log_f, "r") as f:
+        log = f.readlines()
+    log = [line.strip() for line in log if "R script" in line]
+
     found_parallelism = False
     for line in range(len(log) - 1):
         if "R script started running." in log[line] and "R script started running." in log[line + 1]:

--- a/tests/scripts/other_langs/r_failure_exit_code/config.yaml
+++ b/tests/scripts/other_langs/r_failure_exit_code/config.yaml
@@ -1,0 +1,16 @@
+objective:
+    metrics:
+        - name: metric
+scheduler:
+    n_trials: 15
+
+parameters:
+    x0:
+        'bounds': [ 0, 1 ]
+        'type': 'range'
+        'value_type': 'float'
+
+
+script_options:
+    run_model: Rscript run_model.R
+    exp_name: "r_error_exit_code"

--- a/tests/scripts/other_langs/r_failure_exit_code/run_model.R
+++ b/tests/scripts/other_langs/r_failure_exit_code/run_model.R
@@ -1,0 +1,1 @@
+stop("Always throw error for testing purposes.")

--- a/tests/scripts/other_langs/r_package_light/run_model.R
+++ b/tests/scripts/other_langs/r_package_light/run_model.R
@@ -1,6 +1,10 @@
 library(jsonlite)
 source("../r_utils/hartman6.R")
 
+# Additional printing and sleeping for unit testing
+print("R script started running.")
+Sys.sleep(2)
+
 # This is where we read in from BOA the command line argument.
 # If in your script, you use any other command line arguments,
 # generally BOA's trial_dir should be the last command line arugment,
@@ -20,7 +24,6 @@ x5 <- data$x5
 X <- c(x0, x1, x2, x3, x4, x5)
 
 res <- hartman6(X)
-
 if (!is.na(res)) {
     out_data <- list(
         TrialStatus=unbox("COMPLETED")
@@ -44,3 +47,5 @@ if (!is.na(res)) {
     json_data <- toJSON(out_data, pretty = TRUE)
     write(json_data, file.path(trial_dir, "TrialStatus.json"))
 }
+# Additional printing for unit testing
+print("R script finished running.")


### PR DESCRIPTION
- [Updates to move subprocess logging to own thread for parallelism](https://github.com/madeline-scyphers/boa/commit/62cdd4db983916337b628bc857ea3188eabb3e77) 
  subprocess logging happens in own thread to support parallelism,
  and occasionally reads from popen output to put to log.
  All log messages are put into a queue so that they don't write on top of each other.
- [Move r test runs to own fixtures instead of dynamic fixture for caching](https://github.com/madeline-scyphers/boa/commit/5244f552ac1635c965584c2d3804c739940ea1f4) 
  If each fixture runs one script we can say it only runs once per test suite,
  saving time.
