### PR TITLE
send JinjaTemplateVars through to template on config file load always.

### DIFF
--- a/boa/controller.py
+++ b/boa/controller.py
@@ -78,7 +78,11 @@ class Controller:
             # Copy the experiment config to the experiment directory
             shutil.copyfile(config_path, wrapper.experiment_dir / Path(config_path).name)
         else:
-            yaml_dump(wrapper.config, wrapper.experiment_dir / "config.yaml")
+            if wrapper.config.orig_config:
+                d = wrapper.config.orig_config
+            else:
+                d = wrapper.config.to_dict()
+            yaml_dump(d, wrapper.experiment_dir / "config.yaml")
 
         self.wrapper = wrapper
         self.config = self.wrapper.config

--- a/boa/template.py
+++ b/boa/template.py
@@ -2,19 +2,38 @@ from __future__ import annotations
 
 import importlib
 import pathlib
-from enum import Enum
 from typing import Optional
 
 import jinja2
+from attrs import asdict, define
 
 
-class JinjaTemplateVars(Enum):
+@define
+class JinjaTemplateVars:
     """These are the variables that are passed to the jinja2 template.
-    They should always be able to be used in your template (config file)."""
+    They should always be able to be used in your template (config file)
+    assuming you are not rendering the jinja template yourself directly.
 
-    config_path = "Full path to the config file."
-    config_dir_name = "Name of the directory containing the config file."
-    config_file_name = "Name of the config file."
+    config_path: Full path to the config file.
+    config_dir_name: Name of the directory containing the config file.
+    config_file_name: Name of the config file.
+    """
+
+    config_path: pathlib.Path
+    config_dir: pathlib.Path
+    config_dir_name: str
+    config_file_name: str
+
+    def __init__(self, config_path: pathlib.Path):
+        config_dir = config_path.parent
+        config_dir_name = config_dir.name
+        config_file_name = config_path.name
+        self.__attrs_init__(
+            config_path=config_path,
+            config_dir=config_dir,
+            config_dir_name=config_dir_name,
+            config_file_name=config_file_name,
+        )
 
 
 def render_template_from_path(path, template_kw: Optional[dict] = None, **kwargs):
@@ -32,11 +51,7 @@ def render_template_from_path(path, template_kw: Optional[dict] = None, **kwargs
     """
     path = pathlib.Path(path)
     with open(path) as f:
-        kw = {
-            JinjaTemplateVars.config_path.name: path,
-            JinjaTemplateVars.config_dir_name.name: path.parent.name,
-            JinjaTemplateVars.config_file_name.name: path.name,
-        }
+        kw = asdict(JinjaTemplateVars(path))
         rendered = render_template(f.read(), template_kw, **kwargs, **kw)
     return rendered
 

--- a/boa/wrappers/wrapper_utils.py
+++ b/boa/wrappers/wrapper_utils.py
@@ -18,13 +18,13 @@ from contextlib import contextmanager
 from functools import wraps
 from typing import TYPE_CHECKING, Type
 
-import ruamel.yaml as yaml
 from attrs import asdict
 from ax.core.base_trial import BaseTrial
 from ax.core.parameter import ChoiceParameter, FixedParameter, RangeParameter
 from ax.exceptions.core import AxError
 from ax.storage.json_store.encoder import object_to_json
 from ax.utils.common.docutils import copy_doc
+from ruamel.yaml import YAML
 
 from boa.definitions import IS_WINDOWS, PathLike, PathLike_tup
 from boa.logger import get_logger
@@ -229,7 +229,8 @@ def load_yaml_from_str(string: str, render_jinja: bool = True, **kwargs):
     """Load yaml from a string with jinja2 optional templating"""
     if render_jinja:
         string = render_template(string, **kwargs)
-    return yaml.safe_load(string)
+    yaml = YAML(typ="safe", pure=True)
+    return yaml.load(string)
 
 
 @copy_doc(load_json)

--- a/boa/wrappers/wrapper_utils.py
+++ b/boa/wrappers/wrapper_utils.py
@@ -19,6 +19,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Type
 
 import ruamel.yaml as yaml
+from attrs import asdict
 from ax.core.base_trial import BaseTrial
 from ax.core.parameter import ChoiceParameter, FixedParameter, RangeParameter
 from ax.exceptions.core import AxError
@@ -27,7 +28,7 @@ from ax.utils.common.docutils import copy_doc
 
 from boa.definitions import IS_WINDOWS, PathLike, PathLike_tup
 from boa.logger import get_logger
-from boa.template import render_template
+from boa.template import JinjaTemplateVars, render_template
 from boa.utils import (
     _load_attr_from_module,
     _load_module_from_path,
@@ -236,10 +237,11 @@ def load_jsonlike(file: PathLike, **kwargs) -> dict:
     file = pathlib.Path(file)
     # use all suffixes to allow for .json.jinja2 or .yaml.j2 etc
     suffixes = {ext.lstrip(".").lower() for ext in file.suffixes}
+    kw = asdict(JinjaTemplateVars(file))
     if suffixes & {"yaml", "yml"}:
-        return load_yaml(file, **kwargs)
+        return load_yaml(file, **kwargs, **kw)
     elif "json" in suffixes:
-        return load_json(file, **kwargs)
+        return load_json(file, **kwargs, **kw)
     else:
         raise ValueError(
             f"Invalid config file format for config file {file}"


### PR DESCRIPTION
JinjaTemplateVars were only being sent through if calling `render_template_from_path` not if calling `render_template` directly. the `load_jsonlike` functions used `render_template` because the loaded the config file into a str and then rendered. So they didn't get the jinja template vars.