### PR TITLE
Add the ability to pass in parameters to your script options cmds via jinja2

### DIFF
--- a/boa/scheduler.py
+++ b/boa/scheduler.py
@@ -79,7 +79,7 @@ class Scheduler(AxScheduler):
             trials_ls = trials_ls[0]
         update = (
             f"Trials so far: {len(self.experiment.trials)}"
-            f"\nRunning trials: {trials_ls}"
+            f"\nCurrently running trials: {trials_ls}"
             f"\nWill Produce next trials from generation step: {self.generation_strategy.current_step.model_name}"
             f"{best_trial_str}"
         )

--- a/boa/template.py
+++ b/boa/template.py
@@ -71,6 +71,8 @@ def render_template(source: str, template_kw: Optional[dict] = None, **kwargs):
     """
     template_kw = template_kw if template_kw is not None else {}
     template_kw.setdefault("extensions", []).append("jinja2.ext.do")
+    if "undefined" not in template_kw:
+        template_kw["undefined"] = jinja2.DebugUndefined
     kwargs["load_py"] = importlib.import_module
     template = jinja2.Template(source, **template_kw)
     return template.render(

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 - domdfcoding
 dependencies:
-- python=3.10
+- python=3.11
   # mac x86 or apple silicone macs on rosetta python need pytorch>2
   # so if on either of those, it should install pytorch>2 by default
   # but if not and something doesn't work, upgrade pytorch, torchvision,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
 ]
 dynamic = ["version", "dependencies", "optional-dependencies"]
@@ -35,7 +36,7 @@ write_to = "boa/_version.py"
 [tool.isort]
 profile = "black"
 multi_line_output = 3
-py_version = 39
+py_version = 311
 skip_glob = ["*env*/*"]
 
 [tool.black]
@@ -86,4 +87,3 @@ addopts = "--doctest-modules --doctest-glob='*.rst'"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 norecursedirs = "_build"
 filterwarnings = ["ignore::DeprecationWarning:invoke"]
-

--- a/tests/scripts/other_langs/r_package_light/config.yaml
+++ b/tests/scripts/other_langs/r_package_light/config.yaml
@@ -38,7 +38,7 @@ parameters:
         'value_type': 'float'
 
 script_options:
-    run_model: Rscript run_model.R
+    run_model: Rscript run_model.R {{ x0 }} {{ x1 }}
 
 model_options:
     input_size: 15

--- a/tests/scripts/other_langs/r_package_light/run_model.R
+++ b/tests/scripts/other_langs/r_package_light/run_model.R
@@ -15,8 +15,11 @@ trial_dir <- args[length(args)]
 param_path <- file.path(trial_dir, "parameters.json")
 data <- read_json(path=param_path)
 
-x0 <- data$x0
-x1 <- data$x1
+# We pull these from command line arguments defined from jinja2 template in the config
+# to test that we can for testing
+x0 <- as.numeric(args[1])
+x1 <- as.numeric(args[2])
+
 x2 <- data$x2
 x3 <- data$x3
 x4 <- data$x4


### PR DESCRIPTION
with jinja2 formatting you can now pass in your parameters to your run_model cmd or other cmds and each trial will get its unique parameters.