### PR TITLE
Feature/outcome constraints metrics as passthrough bug

### DIFF
--- a/boa/config/config.py
+++ b/boa/config/config.py
@@ -910,6 +910,8 @@ def update_dict(original: dict, param: dict):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from tests.conftest import TEST_CONFIG_DIR
+    from boa.definitions import ROOT
+
+    TEST_CONFIG_DIR = ROOT / "tests" / "test_configs"
 
     c = BOAConfig.from_jsonlike(pathlib.Path(TEST_CONFIG_DIR / "test_config_generic.yaml"))

--- a/tests/1unit_tests/test_config_instantiation.py
+++ b/tests/1unit_tests/test_config_instantiation.py
@@ -1,5 +1,7 @@
 from boa import BOAConfig
-from tests.conftest import TEST_CONFIG_DIR
+from boa.definitions import ROOT
+
+TEST_CONFIG_DIR = ROOT / "tests" / "test_configs"
 
 
 def test_config_instantiation():

--- a/tests/1unit_tests/test_jinja.py
+++ b/tests/1unit_tests/test_jinja.py
@@ -1,5 +1,7 @@
 from boa import BOAConfig, load_json_from_str, load_jsonlike, load_yaml_from_str
-from tests.conftest import TEST_CONFIG_DIR
+from boa.definitions import ROOT, PathLike
+
+TEST_CONFIG_DIR = ROOT / "tests" / "test_configs"
 
 
 def test_config_with_jinja2():

--- a/tests/integration_tests/test_async_opt.py
+++ b/tests/integration_tests/test_async_opt.py
@@ -9,8 +9,9 @@ from pandas.testing import assert_frame_equal
 
 from boa import split_shell_command
 from boa.async_opt import main
-from boa.definitions import PathLike
-from tests.conftest import TEST_CONFIG_DIR
+from boa.definitions import ROOT, PathLike
+
+TEST_CONFIG_DIR = ROOT / "tests" / "test_configs"
 
 rng = np.random.default_rng()
 

--- a/tests/scripts/other_langs/r_package_light/config.yaml
+++ b/tests/scripts/other_langs/r_package_light/config.yaml
@@ -1,7 +1,8 @@
 objective: # can also use the key moo
     metrics:
         - name: metric
-          metric: mean
+    outcome_constraints:
+        - l2norm <= 1.25
 generation_strategy:
     steps:
         - model: SOBOL

--- a/tests/scripts/other_langs/r_package_light/run_model.R
+++ b/tests/scripts/other_langs/r_package_light/run_model.R
@@ -37,9 +37,8 @@ if (!is.na(res)) {
 
 
     out_data <- list(
-        metric=list(
-            a=res
-        )
+        metric=res,
+        l2norm=sum(X**2)**(1/2)
     )
 
     json_data <- toJSON(out_data, pretty = TRUE)


### PR DESCRIPTION
[Fix bug where outcome_constraints didn't create proper metric under h…](https://github.com/madeline-scyphers/boa/commit/7916e366b3e33f6f52400c90f6a01d5f32be2561) 
  …ood and didn't work
  
  Also add metric data fetching caching
  
  outcome_constraints create their own black box constraint, and therefore a new metric.
  This needs to be a passthrough metric, but was creating an Ax Metric class, which didn't work.
  
  Also implement ModularMetric trial data caching which should help when reloading schedular in situations where your wrapper isn't present.