### PR TITLE
Feature/return nan from script for failure

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -77,7 +77,7 @@ jobs:
         with:
             miniforge-variant: Mambaforge
             miniforge-version: latest
-            python-version: '3.10'
+            python-version: '3.11'
             activate-environment: boa
             use-mamba: true
 

--- a/boa/async_opt.py
+++ b/boa/async_opt.py
@@ -130,7 +130,7 @@ def run(config_path, scheduler_path, num_trials, experiment_dir=None):
             scheduler.options = dataclasses.replace(scheduler.options, total_trials=num_trials)
     else:
         controller = Controller(config_path=config_path, wrapper=SyntheticWrapper(config=config))
-        controller.initialize_scheduler()
+        controller.initialize_scheduler(get_exp_kw={"check_for_nans": False})
         scheduler = controller.scheduler
 
     if not scheduler.opt_csv.exists() and scheduler.experiment.trials:
@@ -140,7 +140,7 @@ def run(config_path, scheduler_path, num_trials, experiment_dir=None):
         )
 
     if scheduler.opt_csv.exists():
-        exp_attach_data_from_opt_csv(list(config.objective.metric_names), scheduler)
+        exp_attach_data_from_opt_csv(config.objective.metric_names, scheduler)
 
     generator_runs = scheduler.generation_strategy._gen_multiple(
         experiment=scheduler.experiment, num_generator_runs=scheduler.wrapper.config.trials
@@ -186,7 +186,7 @@ def exp_attach_data_from_opt_csv(metric_names, scheduler):
     new_data = df.loc[df["trial_index"].isin(nan_trials)]
     if new_data.empty:
         return
-    metric_data = new_data[metric_names].to_dict()
+    metric_data = new_data[list(metric_names)].to_dict()
     if check_min_package_version("ax-platform", "0.3.3"):
         kw = dict(combine_with_last_data=True)
     else:

--- a/boa/async_opt.py
+++ b/boa/async_opt.py
@@ -156,20 +156,19 @@ def run(config_path, scheduler_path, num_trials, experiment_dir=None):
     if scheduler.experiment.fetch_data().df.empty:
         trials = scheduler.experiment.trials
         metrics = scheduler.experiment.metrics
-        for metric in metrics.keys():
-            scheduler.experiment.attach_data(
-                Data(
-                    df=pd.DataFrame.from_records(
-                        dict(
-                            trial_index=list(trials.keys()),
-                            arm_name=[f"{i}_0" for i in trials.keys()],
-                            metric_name=metric,
-                            mean=None,
-                            sem=0.0,
-                        )
+        scheduler.experiment.attach_data(
+            Data(
+                df=pd.DataFrame(
+                    dict(
+                        trial_index=[i for i in trials.keys() for m in metrics.keys()],
+                        arm_name=[f"{i}_0" for i in trials.keys() for m in metrics.keys()],
+                        metric_name=[m for i in trials.keys() for m in metrics.keys()],
+                        mean=None,
+                        sem=0.0,
                     )
                 )
             )
+        )
 
     scheduler.save_data(metrics_to_end=True, ax_kwargs=dict(always_include_field_columns=True))
     return scheduler

--- a/boa/ax_instantiation_utils.py
+++ b/boa/ax_instantiation_utils.py
@@ -87,13 +87,10 @@ def get_experiment(config: BOAConfig, runner: Runner, wrapper: BaseWrapper = Non
     search_space = instantiate_search_space_from_json(config.parameters, config.parameter_constraints)
 
     info_only_metrics = BoaInstantiationBase.get_metrics_from_obj_config(
-        config.objective, wrapper=wrapper, info_only=True
+        config.objective, wrapper=wrapper, info_only=True, **kwargs
     )
 
-    optimization_config = BoaInstantiationBase.make_optimization_config(
-        config.objective,
-        wrapper=wrapper,
-    )
+    optimization_config = BoaInstantiationBase.make_optimization_config(config.objective, wrapper=wrapper, **kwargs)
 
     exp = Experiment(
         search_space=search_space,

--- a/boa/config/config.py
+++ b/boa/config/config.py
@@ -289,7 +289,7 @@ class BOAObjective(_Utils):
 
     @property
     def metric_names(self):
-        return (metric.name for metric in self.metrics)
+        return [metric.name for metric in self.metrics]
 
 
 @define

--- a/boa/config/converters.py
+++ b/boa/config/converters.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from .config import BOAMetric
 
 
+STOPPING_STRATEGY_MAPPING = {"improvement": "ImprovementGlobalStoppingStrategy"}
+
+
 def _convert_noton_type(converter, type_, default_if_none=None) -> Any:
     def type_converter(val):
         if default_if_none is not None and val is None:
@@ -66,6 +69,8 @@ def _load_stopping_strategy(d: Optional[dict], module: ModuleType):
     if "type" not in d:
         raise ValueError("Type missing from stopping strategy key")  # can't work with it if type not set
     type_ = d.pop("type")
+    if type_ in STOPPING_STRATEGY_MAPPING:
+        type_ = STOPPING_STRATEGY_MAPPING[type_]
     for key, value in d.items():
         if isinstance(value, dict):
             d[key] = _load_stopping_strategy(d=value, module=module)

--- a/boa/controller.py
+++ b/boa/controller.py
@@ -114,14 +114,16 @@ class Controller:
         get_logger("ax", filename=str(Path(self.wrapper.experiment_dir) / "optimization.log"))
         return self.logger
 
-    def initialize_scheduler(self, **kwargs) -> tuple[Scheduler, BaseWrapper]:
+    def initialize_scheduler(self, get_exp_kw=None, get_scheduler_kw=None) -> tuple[Scheduler, BaseWrapper]:
         """
         Sets experiment and scheduler
 
         Parameters
         ----------
-        kwargs
-            kwargs to pass to get_experiment and get_scheduler
+        get_exp_kw
+            keyword arguments for :meth:`.get_experiment`
+        get_scheduler_kw
+            keyword arguments for :meth:`.get_scheduler`
 
         Returns
         -------
@@ -129,9 +131,13 @@ class Controller:
         and the second element being your wrapper (both initialized
         and ready to go)
         """
+        get_exp_kw = get_exp_kw or {}
+        get_scheduler_kw = get_scheduler_kw or {}
 
-        self.experiment = get_experiment(self.config, WrappedJobRunner(wrapper=self.wrapper), self.wrapper, **kwargs)
-        self.scheduler = get_scheduler(self.experiment, config=self.config, **kwargs)
+        self.experiment = get_experiment(
+            self.config, WrappedJobRunner(wrapper=self.wrapper), self.wrapper, **get_exp_kw
+        )
+        self.scheduler = get_scheduler(self.experiment, config=self.config, **get_scheduler_kw)
         return self.scheduler, self.wrapper
 
     def run(self, scheduler: Scheduler = None, wrapper: BaseWrapper = None) -> Scheduler:

--- a/boa/metrics/metrics.py
+++ b/boa/metrics/metrics.py
@@ -301,7 +301,7 @@ def get_metric_from_config(config: BOAMetric, instantiate=True, **kwargs) -> Mod
     if config.metric_type == MetricType.METRIC or config.metric_type == MetricType.BOA_METRIC:
         metric = get_metric_by_class_name(instantiate=instantiate, **kw)
     elif config.metric_type == MetricType.SKLEARN_METRIC:
-        kwargs["sklearn_"] = True
+        kw["sklearn_"] = True
         metric = get_metric_by_class_name(instantiate=instantiate, **kw)
     elif config.metric_type == MetricType.SYNTHETIC_METRIC:
         metric = setup_synthetic_metric(instantiate=instantiate, **kw)

--- a/boa/metrics/modular_metric.py
+++ b/boa/metrics/modular_metric.py
@@ -175,6 +175,20 @@ class ModularMetric(NoisyFunctionMetric, metaclass=MetricRegister):
             if self.wrapper
             else {}
         )
+        if isinstance(wrapper_kwargs, dict):
+            nan_checks = list(wrapper_kwargs.values())
+        elif isinstance(wrapper_kwargs, list):
+            nan_checks = wrapper_kwargs
+        else:
+            nan_checks = [wrapper_kwargs]
+        for elem in nan_checks:
+            if (
+                (isinstance(elem, str) and ("nan" == elem.lower() or "na" == elem.lower()))
+                or (isinstance(elem, float) and pd.isna(elem))
+                or (elem is None)
+            ):
+                return Err(f"NaNs in Results for Trial {trial.index}, failing trial")
+
         wrapper_kwargs = wrapper_kwargs if wrapper_kwargs is not None else {}
         if wrapper_kwargs is not None and not isinstance(wrapper_kwargs, dict):
             wrapper_kwargs = {"wrapper_args": wrapper_kwargs}

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - pytorch
 - conda-forge
 dependencies:
-- python=3.10
+- python=3.11
   # mac x86 or Apple Silicon macs on rosetta python need pytorch>2
   # so if on either of those, it should install pytorch>2 by default
   # but if not and something doesn't work, upgrade pytorch, torchvision,

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   # so if on either of those, it should install pytorch>2 by default
   # but if not and something doesn't work, upgrade pytorch, torchvision,
   # and torchaudio
+  # Windows will need to install pytorch from the pytorch channel first
 - pytorch<3
 - numpy<2
 - pandas<3
@@ -18,6 +19,6 @@ dependencies:
 - notebook>=5.3
 - ipywidgets>=7.5
 - ax-platform  >=0.3.1,<=0.3.5
-- ruamel.yaml<1
+- ruamel.yaml <1
 - attrs<24
 - jinja2<4

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: boa
 channels:
-- pytorch
 - conda-forge
 dependencies:
 - python=3.11
@@ -8,7 +7,7 @@ dependencies:
   # so if on either of those, it should install pytorch>2 by default
   # but if not and something doesn't work, upgrade pytorch, torchvision,
   # and torchaudio
-- pytorch::pytorch
+- pytorch<3
 - numpy<2
 - pandas<3
 - scipy<2

--- a/environment.yml
+++ b/environment.yml
@@ -9,16 +9,16 @@ dependencies:
   # but if not and something doesn't work, upgrade pytorch, torchvision,
   # and torchaudio
 - pytorch::pytorch
-- numpy
-- pandas
-- scipy
-- scikit-learn
-- click
-- panel
+- numpy<2
+- pandas<3
+- scipy<2
+- scikit-learn<2
+- click<9
+- panel<2
 - plotly>=5.10.0
 - notebook>=5.3
 - ipywidgets>=7.5
 - ax-platform  >=0.3.1,<=0.3.5
-- ruamel.yaml
-- attrs
-- jinja2
+- ruamel.yaml<1
+- attrs<24
+- jinja2<4

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,6 +1,5 @@
 name: boa-dev
 channels:
-- pytorch
 - conda-forge
 - domdfcoding
 dependencies:
@@ -9,21 +8,21 @@ dependencies:
   # so if on either of those, it should install pytorch>2 by default
   # but if not and something doesn't work, upgrade pytorch, torchvision,
   # and torchaudio
-- pytorch::pytorch
-- numpy
-- pandas
-- scipy
-- scikit-learn
-- click
-- panel
+- pytorch<3
+- numpy<2
+- pandas<3
+- scipy<2
+- scikit-learn<2
+- click<9
+- panel<2
 - plotly>=5.10.0
 - notebook>=5.3
 - ipywidgets>=7.5
 - ax-platform==0.3.5
-- ruamel.yaml
+- ruamel.yaml<1
 - domdfcoding::attr_utils
-- attrs
-- jinja2
+- attrs<24
+- jinja2<4
 
   ## Jupyter and sphinx jupyter
 - myst-nb

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -8,7 +8,7 @@ dependencies:
   # so if on either of those, it should install pytorch>2 by default
   # but if not and something doesn't work, upgrade pytorch, torchvision,
   # and torchaudio
-- pytorch<3
+- pytorch::pytorch<3
 - numpy<2
 - pandas<3
 - scipy<2

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DEV_ENV = Path(__file__).resolve().parent / "environment_dev.yml"
 # ex) PyTorch is pytorch on conda, but listed as torch on PyPI
 # also if you are installing a pkg from a git rep, you should remap it
 # to "git+https/etc": "pkg_name @ git+https/etc"
-pkg_renames = {"pytorch": "torch"}
+pkg_renames = {"pytorch<3": "torch<3"}
 
 
 # list of any packages in your environment files you don't want to include

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -96,6 +96,13 @@ def test_cli_interface_with_failing_test_that_sends_back_failed_trial_status():
         dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)
 
 
+@pytest.mark.skipif(not R_INSTALLED, reason="requires R to be installed")
+def test_cli_interface_with_failing_test_that_sends_back_failed_trial_status():
+    with pytest.raises(FailureRateExceededError):
+        config_path = ROOT / "tests" / f"scripts/other_langs/r_pass_back_fail_trial_status/config.yaml"
+        dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)
+
+
 def test_wrapper_with_custom_load_config():
     # This should fail with a failing config
     config_path = ROOT / "tests" / f"scripts/other_langs/r_package_streamlined/config_fail.yaml"

--- a/tests/integration_tests/test_dunder_main.py
+++ b/tests/integration_tests/test_dunder_main.py
@@ -130,3 +130,9 @@ def test_non_zero_exit_code_fails_trial():
     with pytest.raises(FailureRateExceededError):
         config_path = ROOT / "tests" / f"scripts/other_langs/r_failure_exit_code/config.yaml"
         dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)
+
+
+def test_return_nan_fails_trial():
+    with pytest.raises(FailureRateExceededError):
+        config_path = ROOT / "tests" / f"scripts/other_langs/r_failure_nan/config.yaml"
+        dunder_main.main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)

--- a/tests/scripts/other_langs/r_failure_nan/config.yaml
+++ b/tests/scripts/other_langs/r_failure_nan/config.yaml
@@ -1,0 +1,16 @@
+objective:
+    metrics:
+        - name: metric
+scheduler:
+    n_trials: 10
+
+parameters:
+    x0:
+        'bounds': [ 0, 1 ]
+        'type': 'range'
+        'value_type': 'float'
+
+
+script_options:
+    run_model: Rscript run_model.R
+    exp_name: "r_error_nan"

--- a/tests/scripts/other_langs/r_failure_nan/run_model.R
+++ b/tests/scripts/other_langs/r_failure_nan/run_model.R
@@ -1,0 +1,8 @@
+library(jsonlite)
+args <- commandArgs(trailingOnly=TRUE)
+trial_dir <- args[length(args)]
+out_data <- list(
+    metric=NaN
+)
+json_data <- toJSON(out_data, pretty = TRUE)
+write(json_data, file.path(trial_dir, "output.json"))

--- a/tests/scripts/other_langs/r_pass_back_fail_trial_status/config.yaml
+++ b/tests/scripts/other_langs/r_pass_back_fail_trial_status/config.yaml
@@ -1,0 +1,46 @@
+objective: # can also use the key moo
+    metrics:
+        - name: metric
+    outcome_constraints:
+        - l2norm <= 1.25
+generation_strategy:
+    steps:
+        - model: SOBOL
+          num_trials: 5
+        - model: GPEI
+          num_trials: -1
+scheduler:
+    total_trials: 15
+
+parameters:
+    x0:
+        'bounds': [ 0, 1 ]
+        'type': 'range'
+        'value_type': 'float'
+    x1:
+        'bounds': [ 0, 1]
+        'type': 'range'
+        'value_type': 'float'
+    x2:
+        'bounds': [ 0, 1 ]
+        'type': 'range'
+        'value_type': 'float'
+    x3:
+        'bounds': [ 0, 1]
+        'type': 'range'
+        'value_type': 'float'
+    x4:
+        'bounds': [ 0, 1 ]
+        'type': 'range'
+        'value_type': 'float'
+    x5:
+        'bounds': [ 0, 1]
+        'type': 'range'
+        'value_type': 'float'
+
+script_options:
+    run_model: Rscript run_model.R {{ trial_dir }} {{ x0 }} {{ x1 }}
+
+model_options:
+    input_size: 15
+    model_dir: .

--- a/tests/scripts/other_langs/r_pass_back_fail_trial_status/run_model.R
+++ b/tests/scripts/other_langs/r_pass_back_fail_trial_status/run_model.R
@@ -1,0 +1,16 @@
+# load in any libraries and modules we need
+library(jsonlite)
+
+# This is where we read in from BOA the command line argument.
+# If in your script, you use any other command line arguments,
+# generally BOA's trial_dir should be the last command line arugment,
+# so taking the last one should generally be safe.
+args <- commandArgs(trailingOnly=TRUE)
+trial_dir <- args[length(args)]
+
+out_data <- list(
+        trial_status=unbox("FAILED")
+    )
+
+json_data <- toJSON(out_data, pretty = TRUE)
+write(json_data, file.path(trial_dir, "output.json"))

--- a/tests/test_configs/test_config_generic.yaml
+++ b/tests/test_configs/test_config_generic.yaml
@@ -62,5 +62,7 @@ generation_strategy:
 scheduler:
     total_trials: 10
     global_stopping_strategy:
-        type: ImprovementGlobalStoppingStrategy
+        type: improvement
         min_trials: 7
+        window_size: 3
+        improvement_bar: 0.01


### PR DESCRIPTION
- [Add ability to return nan/null from script to mark failure](https://github.com/madeline-scyphers/boa/commit/54d5f4a3f52da7d22e0cabcf36f7de75daafe4a1)
  When running a script if your function fails and you get a nan or null or some sort
  you can now just pass that along to BOA instead of checking and marking your test as failed
  BOA will mark it as failed for you.
- [Version pinning because numpy 2.0 broke Ax](https://github.com/madeline-scyphers/boa/commit/33f0f65511cf0a33e819e88c5b8c3341e89c2d12)