### PR TITLE
Package/update ax to 0.3.6

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,14 +34,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu
-            label: linux-64-0.4.0
-            prefix: /usr/share/miniconda3/envs/boa
-            ax_version: 0.4.0
-          - os: ubuntu
-            label: linux-64-0.3.7
-            prefix: /usr/share/miniconda3/envs/boa
-            ax_version: 0.3.7
+#          # something in 0.3.7 was introduced that caused both run_n_trials and run_all_trials to not run
+#          # the expected number of trials. Removing support for 0.3.7 and above until we can figure out what's going on
+#          - os: ubuntu
+#            label: linux-64-0.4.0
+#            prefix: /usr/share/miniconda3/envs/boa
+#            ax_version: 0.4.0
+#          - os: ubuntu
+#            label: linux-64-0.3.7
+#            prefix: /usr/share/miniconda3/envs/boa
+#            ax_version: 0.3.7
           - os: ubuntu
             label: linux-64-0.3.6
             prefix: /usr/share/miniconda3/envs/boa

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,10 +34,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - os: ubuntu  # broken right now with Gen Strat eq check
-#            label: linux-64-0.3.6
-#            prefix: /usr/share/miniconda3/envs/boa
-#            ax_version: 0.3.6
+          - os: ubuntu
+            label: linux-64-0.3.7
+            prefix: /usr/share/miniconda3/envs/boa
+            ax_version: 0.3.7
+          - os: ubuntu
+            label: linux-64-0.3.6
+            prefix: /usr/share/miniconda3/envs/boa
+            ax_version: 0.3.6
           - os: ubuntu
             label: linux-64-0.3.5
             prefix: /usr/share/miniconda3/envs/boa

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -35,6 +35,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu
+            label: linux-64-0.4.0
+            prefix: /usr/share/miniconda3/envs/boa
+            ax_version: 0.4.0
+          - os: ubuntu
             label: linux-64-0.3.7
             prefix: /usr/share/miniconda3/envs/boa
             ax_version: 0.3.7

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - plotly>=5.10.0
 - notebook>=5.3
 - ipywidgets>=7.5
-- ax-platform  >=0.3.1,<=0.3.7
+- ax-platform  >=0.3.1,<=0.4.0,!=0.3.7
 - ruamel.yaml <1
 - attrs<24
 - jinja2<4

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - plotly>=5.10.0
 - notebook>=5.3
 - ipywidgets>=7.5
-- ax-platform  >=0.3.1,<=0.3.5
+- ax-platform  >=0.3.1,<=0.3.7
 - ruamel.yaml <1
 - attrs<24
 - jinja2<4

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,10 @@ dependencies:
 - plotly>=5.10.0
 - notebook>=5.3
 - ipywidgets>=7.5
-- ax-platform  >=0.3.1,<=0.4.0,!=0.3.7
+# something in 0.3.7 was introduced that caused both run_n_trials and run_all_trials to not run
+# the expected number of trials. Removing support for 0.3.7 and above until we can figure out what's going on
+# When fixed, add back into environment_dev.yml and CI.yaml
+- ax-platform  >=0.3.1,<=0.3.6
 - ruamel.yaml <1
 - attrs<24
 - jinja2<4

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -18,7 +18,7 @@ dependencies:
 - plotly>=5.10.0
 - notebook>=5.3
 - ipywidgets>=7.5
-- ax-platform==0.3.7
+- ax-platform==0.4.0
 - ruamel.yaml<1
 - domdfcoding::attr_utils
 - attrs<24

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -18,7 +18,7 @@ dependencies:
 - plotly>=5.10.0
 - notebook>=5.3
 - ipywidgets>=7.5
-- ax-platform==0.3.5
+- ax-platform==0.3.7
 - ruamel.yaml<1
 - domdfcoding::attr_utils
 - attrs<24

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -18,7 +18,7 @@ dependencies:
 - plotly>=5.10.0
 - notebook>=5.3
 - ipywidgets>=7.5
-- ax-platform==0.4.0
+- ax-platform==0.3.6
 - ruamel.yaml<1
 - domdfcoding::attr_utils
 - attrs<24

--- a/tests/1unit_tests/test_generation_strategy.py
+++ b/tests/1unit_tests/test_generation_strategy.py
@@ -20,6 +20,14 @@ def test_gen_steps_from_config(gen_strat1_config):
             GenerationStep(model=Models.GPEI, num_trials=-1),
         ],
     )
+    # we call repr to ensure that the generation strategy is correctly initialized
+    # because in ax 0.3.6, GS dynamically adds an attribute to the GS object
+    # So, we can't directly compare the objects yet, because their __dict__ size will change
+    # during runtime and raise a RuntimeError
+    # Stupid I know, as of 2024-07-05 they still haven't merged the PR to fix this
+    repr(gs1)
+    repr(gs2)
+
     assert gs1 == gs2
 
 


### PR DESCRIPTION
# Summary

- [Add Ax 0.3.6 support](https://github.com/madeline-scyphers/boa/commit/b114a5b9576ece265212cef86e9cb9eb6db28122)
- [Test Ax 0.3.7 and 0.4.0](https://github.com/madeline-scyphers/boa/commit/4eb444ce65f8cad1b5ff4ba2c826d706c4d9eecb)
- [Remove support for Ax 0.3.7 and 0.4.0](https://github.com/madeline-scyphers/boa/commit/240109f27e63160cb022672d452885182106a135)
  something in 0.3.7 was introduced that caused both `run_n_trials` and `run_all_trials` to not run the expected number of trials. Removing support for 0.3.7 and above until we can figure out what's going on