### PR TITLE
Add BoTorch_Modular to config, giving custom GP and acq func ability

### DIFF
--- a/boa/config/converters.py
+++ b/boa/config/converters.py
@@ -15,6 +15,8 @@ from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.service.utils.instantiation import TParameterRepresentation
 from ax.service.utils.scheduler_options import SchedulerOptions
 
+from boa.utils import check_min_package_version
+
 if TYPE_CHECKING:
     from .config import BOAMetric
 
@@ -54,6 +56,12 @@ def _gen_strat_converter(gs: Optional[dict] = None) -> dict:
                 gs["steps"][i] = step
                 steps.append(step)
                 continue
+            if step["model"] == "BOTORCH_MODULAR" and not check_min_package_version("ax-platform", "0.3.5"):
+                raise ValueError(
+                    "BOTORCH_MODULAR model is not available in BOA with Ax version < 0.3.5. "
+                    "Please upgrade to a newer version of Ax."
+                )
+
             if "model_kwargs" in step:
                 if "botorch_acqf_class" in step["model_kwargs"] and not isinstance(
                     step["model_kwargs"]["botorch_acqf_class"], botorch.acquisition.AcquisitionFunction

--- a/boa/config/converters.py
+++ b/boa/config/converters.py
@@ -5,8 +5,13 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import ax.early_stopping.strategies as early_stopping_strats
 import ax.global_stopping.strategies as global_stopping_strats
+import botorch.acquisition
+import botorch.models
+import gpytorch.kernels
+import gpytorch.mlls
 from ax.modelbridge.generation_node import GenerationStep
 from ax.modelbridge.registry import Models
+from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.service.utils.instantiation import TParameterRepresentation
 from ax.service.utils.scheduler_options import SchedulerOptions
 
@@ -49,6 +54,36 @@ def _gen_strat_converter(gs: Optional[dict] = None) -> dict:
                 gs["steps"][i] = step
                 steps.append(step)
                 continue
+            if "model_kwargs" in step:
+                if "botorch_acqf_class" in step["model_kwargs"] and not isinstance(
+                    step["model_kwargs"]["botorch_acqf_class"], botorch.acquisition.AcquisitionFunction
+                ):
+                    step["model_kwargs"]["botorch_acqf_class"] = getattr(
+                        botorch.acquisition, step["model_kwargs"]["botorch_acqf_class"]
+                    )
+
+                if "surrogate" in step["model_kwargs"]:
+                    if "mll_class" in step["model_kwargs"]["surrogate"] and not isinstance(
+                        step["model_kwargs"]["surrogate"]["mll_class"], gpytorch.mlls.MarginalLogLikelihood
+                    ):
+                        step["model_kwargs"]["surrogate"]["mll_class"] = getattr(
+                            gpytorch.mlls, step["model_kwargs"]["surrogate"]["mll_class"]
+                        )
+                    if "botorch_model_class" in step["model_kwargs"]["surrogate"] and not isinstance(
+                        step["model_kwargs"]["surrogate"]["botorch_model_class"], botorch.models.model.Model
+                    ):
+                        step["model_kwargs"]["surrogate"]["botorch_model_class"] = getattr(
+                            botorch.models, step["model_kwargs"]["surrogate"]["botorch_model_class"]
+                        )
+                    if "covar_module_class" in step["model_kwargs"]["surrogate"] and not isinstance(
+                        step["model_kwargs"]["surrogate"]["covar_module_class"], gpytorch.kernels.Kernel
+                    ):
+                        step["model_kwargs"]["surrogate"]["covar_module_class"] = getattr(
+                            gpytorch.kernels, step["model_kwargs"]["surrogate"]["covar_module_class"]
+                        )
+
+                    step["model_kwargs"]["surrogate"] = Surrogate(**step["model_kwargs"]["surrogate"])
+
             try:
                 step["model"] = Models[step["model"]]
             except KeyError:

--- a/boa/registry.py
+++ b/boa/registry.py
@@ -1,4 +1,22 @@
-from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
+from __future__ import annotations
+
+from typing import Type
+
+import botorch.acquisition
+import gpytorch.kernels
+from ax.storage.botorch_modular_registry import (
+    ACQUISITION_FUNCTION_REGISTRY,
+    CLASS_TO_REGISTRY,
+    CLASS_TO_REVERSE_REGISTRY,
+)
+from ax.storage.json_store.registry import (
+    CORE_CLASS_DECODER_REGISTRY,
+    CORE_CLASS_ENCODER_REGISTRY,
+    CORE_DECODER_REGISTRY,
+    CORE_ENCODER_REGISTRY,
+    botorch_modular_to_dict,
+    class_from_json,
+)
 
 
 def config_to_dict(inst):
@@ -15,3 +33,25 @@ def _add_common_encodes_and_decodes():
     CORE_ENCODER_REGISTRY[BOAConfig] = config_to_dict
     # CORE_DECODER_REGISTRY[BOAConfig.__name__] = BOAConfig
     CORE_DECODER_REGISTRY[MetricType.__name__] = MetricType
+
+    CORE_CLASS_DECODER_REGISTRY["Type[Kernel]"] = class_from_json
+    CORE_CLASS_ENCODER_REGISTRY[gpytorch.kernels.Kernel] = botorch_modular_to_dict
+
+    KERNEL_REGISTRY = {getattr(gpytorch.kernels, kernel): kernel for kernel in gpytorch.kernels.__all__}
+
+    REVERSE_KERNEL_REGISTRY: dict[str, Type[gpytorch.kernels.Kernel]] = {v: k for k, v in KERNEL_REGISTRY.items()}
+
+    CLASS_TO_REGISTRY[gpytorch.kernels.Kernel] = KERNEL_REGISTRY
+    CLASS_TO_REVERSE_REGISTRY[gpytorch.kernels.Kernel] = REVERSE_KERNEL_REGISTRY
+
+    for acq_func_name in botorch.acquisition.__all__:
+        acq_func = getattr(botorch.acquisition, acq_func_name)
+        if acq_func not in ACQUISITION_FUNCTION_REGISTRY:
+            ACQUISITION_FUNCTION_REGISTRY[acq_func] = acq_func_name
+
+    REVERSE_ACQUISITION_FUNCTION_REGISTRY: dict[str, Type[botorch.acquisition.AcquisitionFunction]] = {
+        v: k for k, v in ACQUISITION_FUNCTION_REGISTRY.items()
+    }
+
+    CLASS_TO_REGISTRY[botorch.acquisition.AcquisitionFunction] = ACQUISITION_FUNCTION_REGISTRY
+    CLASS_TO_REVERSE_REGISTRY[botorch.acquisition.AcquisitionFunction] = REVERSE_ACQUISITION_FUNCTION_REGISTRY

--- a/docs/user_guide/customizing_gp_acq.md
+++ b/docs/user_guide/customizing_gp_acq.md
@@ -3,7 +3,7 @@
 BOA is designed with flexibility of options for selecting the acquisition function and
 kernel. BOA could be used by advanced BO users that want to control detailed aspects of the
 optimization. However, for non-domain experts of BO, BOA defaults to common sensible
-choices. BOA defers to BoTorch&#39;s defaults of a Matern 5/2 kernel, one of the most widely
+choices. BOA defers to BoTorch's defaults of a Matern 5/2 kernel, one of the most widely
 used and flexible choices for BO and GPs (Frazier, 2018; Riche and Picheny, 2021; Jakeman,
 2023). This is considered to be a flexible and broadly applicable kernel (Riche and Picheny,2021) and it is used as the default by many other BO and GP toolkits (Akiba et al., 2019;
 Balandat et al., 2020; Brea, 2023; Nogueira, 2014; Jakeman, 2023). Similarly, BOA defaults
@@ -38,6 +38,61 @@ generation_strategy:
 
 ## Utilizing Ax's Predefined Kernels and Acquisition Functions
 
+Ax has a number of predefined kernels and acquisition function combos that can be used in the optimization process. Each of these sit inside a "step" inside the generation strategy, where your optimization is broken into a number of "steps" and each step can have its own kernel and acquisition function. For example, the first step is usually a Sobol step that does a quasi-random initialization of the optimization process. The second step could be a "GPEI" step (GPEI is the Ax model class name, and is the default used for single objective optimization) that uses the Matern 5/2 kernel and the batched noisy Expected Improvement acquisition function.
+
+```yaml
+
+generation_strategy:
+    steps:
+        - model: Sobol
+          num_trials: 50
+          # specify the maximum number of trials to run in parallel
+          # 
+          max_parallelism: 10
+        - model: GPEI
+          num_trials: -1  # -1 means the rest of the trials
+          max_parallelism: 10
+``` 
+
+Ax does not have a good spot in their docs currently that lists all the available kernels and acquisition functions combo models, but you can find them listed on their [api docs here](https://ax.dev/api/modelbridge.html#ax.modelbridge.registry.Models) and you can see the source code for the models by clicking the source link on the api docs page. Some of the available models are:
+
+- `GPEI`: Gaussian Process Expected Improvement, the default for single objective optimization, uses the Matern 5/2 kernel
+- `GPKG`: Gaussian Process Knowledge Gradient, uses the Matern 5/2 kernel
+- `SAASBO`: Sparse Axis-Aligned Subspace Bayesian Optimization, see [BO Overview High Dimensionality](bo_overview.md#high-dimensionality) for more details, uses the Matern 5/2 kernel and the batched noisy Expected Improvement acquisition function
+- `Sobol`: Sobol initialization
+- `MOO`: Gaussian Process Expected Hypervolume Improvement, uses the Matern 5/2 kernel
+
+If you want to specify your kernel and acquisition function, you can do so by creating a custom model. The way to do that is with the `BOTORCH_MODULAR` model. This model allows you to specify the kernel and acquisition function you want to use. Here is an example of how to use the `BOTORCH_MODULAR` model:
+
+```yaml
+generation_strategy:
+    steps:
+        - model: SOBOL
+          num_trials: 5
+        - model: BOTORCH_MODULAR
+          num_trials: -1  # No limitation on how many trials should be produced from this step
+          model_kwargs:
+              surrogate:
+                  botorch_model_class: SingleTaskGP  # BoTorch model class name
+                  covar_module_class: RBFKernel  # GPyTorch kernel class name
+                  mll_class: LeaveOneOutPseudoLikelihood  # GPyTorch MarginalLogLikelihood class name
+              botorch_acqf_class: qUpperConfidenceBound  # BoTorch acquisition function class name
+              acquisition_options:
+                  beta: 0.5
+``` 
+
+In the above example, the `BOTORCH_MODULAR` model is used to specify the `SingleTaskGP` model class, the `RBFKernel` kernel class, and the `qUpperConfidenceBound` acquisition function class. The `qUpperConfidenceBound` acquisition function is a batched version of UpperConfidenceBound. The `beta` parameter is a hyperparameter of the acquisition function that controls the trade-off between exploration and exploitation.
+
+BoTorch model classes can be found in the [BoTorch model api documentation](https://botorch.org/docs/models) and the BoTorch acquisition functions can be found in the [BoTorch acquisition api documentation](https://botorch.org/api/acquisition.html).
+
+GPyTorch kernel classes can be found in the [GPyTorch kernel api documentation](https://gpytorch.readthedocs.io/en/latest/kernels.html).
+
+The GPyTorch MarginalLogLikelihood classes can be found in the [GPyTorch MarginalLogLikelihood api documentation](https://gpytorch.readthedocs.io/en/latest/marginal_log_likelihoods.html). But the only MLL class that for sure work currently are `ExactMarginalLogLikelihood` and `LeaveOneOutPseudoLikelihood`. Other MLL classes may work, but they have not been tested and are depended on some other implementation details in Ax.
+
+
+```{caution}
+The `BOTORCH_MODULAR` class is an area of Ax's code that is still under active development and a lot of components of it are very dependent on the current implementation of Ax, BoTorch, and GPyTorch, and therefore it is impossible to test every possible combination of kernel and acquisition function. Therefore, it is recommended to use when possible the predefined models that Ax provides.
+```
 
 
 

--- a/docs/user_guide/customizing_gp_acq.md
+++ b/docs/user_guide/customizing_gp_acq.md
@@ -1,0 +1,60 @@
+# Customizing Your Gaussian Process and Acquisition Function
+
+BOA is designed with flexibility of options for selecting the acquisition function and
+kernel. BOA could be used by advanced BO users that want to control detailed aspects of the
+optimization. However, for non-domain experts of BO, BOA defaults to common sensible
+choices. BOA defers to BoTorch&#39;s defaults of a Matern 5/2 kernel, one of the most widely
+used and flexible choices for BO and GPs (Frazier, 2018; Riche and Picheny, 2021; Jakeman,
+2023). This is considered to be a flexible and broadly applicable kernel (Riche and Picheny,2021) and it is used as the default by many other BO and GP toolkits (Akiba et al., 2019;
+Balandat et al., 2020; Brea, 2023; Nogueira, 2014; Jakeman, 2023). Similarly, BOA defaults
+to Expected Improvement (EI) for single-objective functions and Expected Hypervolume
+Improvement (EHVI) for multi-objective problems, which are well-regarded for their
+performance across a broad range of applications (Balandat et al., 2020; Daulton et al., 2021;
+Frazier, 2018). Users do have the option to explicitly control steps in the optimization process
+in the ‘generation strategy’ section of the configuration, for example, to control the number of
+Sobol trials, if SAASBO should be utilized, etc. As an advanced use case, users can also
+explicitly set up different kernels and acquisition functions for different stages in the
+optimization if they so choose. On this page, we will go over both ways to customize, as well as link to some examples of how to do so.
+
+## General Control Options
+
+The `generation_strategy` section of the configuration file is where you can control the optimization process. This includes the number of Sobol trials, the number of initial points, the number of iterations, and whether to use SAASBO. The `generation_strategy` section is shown below with common options:
+
+```yaml
+generation_strategy:
+    # Specific number of initialization trials, 
+    # Typically, initialization trials are generated quasi-randomly.
+    num_initialization_trials: 50 
+    # Integer, with which to override the default max parallelism setting for all 
+    # steps in the generation strategy returned from this function. Each generation 
+    # step has a ``max_parallelism`` value, which restricts how many trials can run
+    # simultaneously during a given generation step.
+    max_parallelism_override: 10
+    # Whether to use SAAS prior for any GPEI generation steps.
+    # See, BO overview page, high dimensionality section for more details.
+    use_saasbo: true  
+    random_seed: 42  # Fixed random seed for the Sobol generator.
+```
+
+## Utilizing Ax's Predefined Kernels and Acquisition Functions
+
+
+
+
+## References
+
+Akiba, T., Sano, S., Yanase, T., Ohta, T., Koyama, M., 2019. Optuna: A next-generation hyperparameter optimization framework, Proceedings of the 25th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. Association for Computing Machinery: Anchorage, AK, USA, pp. 2623–2631.
+
+Balandat, M., Karrer, B., Jiang, D.R., Daulton, S., Letham, B., Gordon Wilson, A., Bakshy, E., 2020. BOTORCH: a framework for efficient Monte-Carlo Bayesian optimization, Proceedings of the 34th International Conference on Neural Information Processing Systems. Curran Associates Inc.: Vancouver, BC, Canada, pp. 21524–21538.
+
+Brea, J., 2023. BayesianOptimization.jl. https://github.com/jbrea/BayesianOptimization.jl (accessed 17 July 2024)
+
+Daulton, S., Balandat, M., Bakshy, E., 2021. Parallel Bayesian optimization of multiple noisy objectives with expected hypervolume improvement, 35th Conference on Neural Information Processing Systems.
+
+Frazier, P.I., 2018. Bayesian Optimization, Recent Advances in Optimization and Modeling of Contemporary Problems, pp. 255-278.
+
+Jakeman, J.D., 2023. PyApprox: A software package for sensitivity analysis, Bayesian inference, optimal experimental design, and multi-fidelity uncertainty quantification and surrogate modeling. Environmental Modelling & Software 170 105825.
+
+Nogueira, F., 2014. Bayesian Optimization: Open source constrained global optimization tool for Python. https://github.com/bayesian-optimization/BayesianOptimization (accessed 17 July 2024)
+
+Riche, R.L., Picheny, V., 2021. Revisiting Bayesian Optimization in the light of the COCO benchmark. Struct Multidisc Optim 64, 3063–3087. https://doi.org/10.1007/s00158-021-02977-1

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -8,4 +8,5 @@ User guide
     getting_started
     bo_overview
     package_overview
+    customizing_gp_acq
     /api/boa.wrappers

--- a/docs/user_guide/package_overview.rst
+++ b/docs/user_guide/package_overview.rst
@@ -26,8 +26,6 @@ Objective functions
 
 When specifying your objective function to minimize or maximize, :doc:`BOA </index>` comes with a number of metrics you can use with your model output, such as MSE, :math:`R^2`, and others. For a list of current list of premade available of metrics, see See :mod:`.metrics.metrics`
 
-
-
 ************************************************************************
 Creating a model wrapper (Language Agnostic or Python API)
 ************************************************************************
@@ -39,6 +37,17 @@ and there is a standard interface to follow.
 
 
 See the :mod:`instructions for creating a model wrapper <.boa.wrappers>` for details.
+See the :doc:`examples of model wrappers <.boa.wrappers>` for examples.
+See :doc:`tutorials </examples/index>`  for a number of examples of model wrappers in both Python and R.
+
+
+************************************************************************
+Choosing a Custom Kernel and Acquisition Function
+************************************************************************
+
+BOA tries to make it easy to use the default kernel and acquisition function, but if you need to specify a different kernel or acquisition function, you can do so in the configuration file.
+
+See :doc:`details on how to specify kernel and acquisition function <customizing_gp_acq.>` for details.
 
 ****************************************************
 Creating a Python launch script (Usually Not Needed)

--- a/tests/1unit_tests/test_generation_strategy.py
+++ b/tests/1unit_tests/test_generation_strategy.py
@@ -2,6 +2,7 @@ import botorch.acquisition
 import botorch.models
 import gpytorch.kernels
 import gpytorch.mlls
+import pytest
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
 
@@ -47,6 +48,9 @@ def test_auto_gen_use_saasbo(saasbo_config, tmp_path):
         assert "FullyBayesian" in gs.name
 
 
+@pytest.importorskip(
+    "ax-platform", minversion="0.3.5", reason="BOTORCH_MODULAR model is not available in BOA with Ax version < 0.3.5."
+)
 def test_modular_botorch(gen_strat_modular_botorch_config, tmp_path):
     controller = Controller(
         config=gen_strat_modular_botorch_config,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,12 @@ def gen_strat1_config():
 
 
 @pytest.fixture
+def gen_strat_modular_botorch_config():
+    config_path = TEST_DIR / f"scripts/other_langs/r_package_streamlined/config_modular_botorch.yaml"
+    return BOAConfig.from_jsonlike(file=config_path)
+
+
+@pytest.fixture
 def synth_config():
     config_path = TEST_CONFIG_DIR / "test_config_synth.yaml"
     return BOAConfig.from_jsonlike(file=config_path)
@@ -233,3 +239,9 @@ def r_streamlined(tmp_path_factory, cd_to_root_and_back_session):
     config_path = TEST_DIR / f"scripts/other_langs/r_package_streamlined/config.yaml"
 
     yield cli_main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)
+
+
+@pytest.fixture(scope="session")
+def r_streamlined_botorch_modular(tmp_path_factory, cd_to_root_and_back_session):
+    config_path = TEST_DIR / f"scripts/other_langs/r_package_streamlined/config_modular_botorch.yaml"
+    return cli_main(split_shell_command(f"--config-path {config_path} -td"), standalone_mode=False)

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -75,9 +75,12 @@ def test_calling_command_line_test_script_doesnt_error_out_and_produces_correct_
 
 # parametrize the test to use the full version (all scripts) or the light version (only run_model.R)
 # or parametrize the test to use the streamlined version (doesn't use trial_status.json, only use output.json)
+# the botorch modular version is the same as the streamlined version, but also uses botorch modular
+# which uses a custom kernel, acquisition function, mll and botorch model class
+# (which can customize the GP process even more)
 @pytest.mark.parametrize(
     "r_scripts_run",
-    ["r_full", "r_light", "r_streamlined"],
+    ["r_full", "r_light", "r_streamlined", "r_streamlined_botorch_modular"],
 )
 @pytest.mark.skipif(not R_INSTALLED, reason="requires R to be installed")
 def test_calling_command_line_r_test_scripts(r_scripts_run, request):
@@ -92,7 +95,7 @@ def test_calling_command_line_r_test_scripts(r_scripts_run, request):
         assert "param_names" in data
         assert "metric_properties" in data
 
-    if "r_streamlined" == r_scripts_run:
+    if r_scripts_run in ("r_streamlined", "r_streamlined_botorch_modular"):
         with cd_and_cd_back(scheduler.wrapper.config_path.parent):
 
             pre_num_trials = len(scheduler.experiment.trials)

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -12,7 +12,6 @@ from boa import (
     get_trial_dir,
     load_jsonlike,
     scheduler_from_json_file,
-    scheduler_to_json_file,
     split_shell_command,
 )
 from boa.cli import main as cli_main
@@ -80,7 +79,20 @@ def test_calling_command_line_test_script_doesnt_error_out_and_produces_correct_
 # (which can customize the GP process even more)
 @pytest.mark.parametrize(
     "r_scripts_run",
-    ["r_full", "r_light", "r_streamlined", "r_streamlined_botorch_modular"],
+    [
+        "r_full",
+        "r_light",
+        "r_streamlined",
+        "r_streamlined_botorch_modular",
+        pytest.param(
+            "r_streamlined_botorch_modular",
+            marks=pytest.importorskip(
+                "ax-platform",
+                minversion="0.3.5",
+                reason="BOTORCH_MODULAR model is not available in BOA with Ax version < 0.3.5.",
+            ),
+        ),
+    ],
 )
 @pytest.mark.skipif(not R_INSTALLED, reason="requires R to be installed")
 def test_calling_command_line_r_test_scripts(r_scripts_run, request):

--- a/tests/scripts/other_langs/r_package_streamlined/config_modular_botorch.yaml
+++ b/tests/scripts/other_langs/r_package_streamlined/config_modular_botorch.yaml
@@ -54,7 +54,7 @@ generation_strategy:
                   botorch_model_class: SingleTaskGP  # BoTorch model class name
 
                   covar_module_class: RBFKernel  # GPyTorch kernel class name
-                  mll_class: LeaveOneOutPseudoLikelihood
+                  mll_class: LeaveOneOutPseudoLikelihood  # GPyTorch MarginalLogLikelihood class name
               botorch_acqf_class: qUpperConfidenceBound  # BoTorch acquisition function class name
               acquisition_options:
                   beta: 0.5

--- a/tests/scripts/other_langs/r_package_streamlined/config_modular_botorch.yaml
+++ b/tests/scripts/other_langs/r_package_streamlined/config_modular_botorch.yaml
@@ -1,0 +1,60 @@
+objective:
+    metrics:
+        - name: metric
+scheduler:
+    n_trials: 15
+
+parameters:
+    x0:
+        'bounds': [ 0, 1 ]
+        'type': 'range'
+        'value_type': 'float'
+    x1:
+        'bounds': [ 0, 1]
+        'type': 'range'
+        'value_type': 'float'
+    x2:
+        'bounds': [ 0, 1 ]
+        'type': 'range'
+        'value_type': 'float'
+    x3:
+        'bounds': [ 0, 1]
+        'type': 'range'
+        'value_type': 'float'
+    x4:
+        'bounds': [ 0, 1 ]
+        'type': 'range'
+        'value_type': 'float'
+    x5:
+        'bounds': [ 0, 1]
+        'type': 'range'
+        'value_type': 'float'
+
+script_options:
+    # notice here that this is a shell command
+    # this is what BOA will do to launch your script
+    # it will also pass as a command line argument the current trial directory
+    # that is being parameterized
+
+    # This can either be a relative path or absolute path
+    # (by default when BOA launches from a config file
+    # it uses the config file directory as your working directory)
+    # here config.yaml and run_model.R are in the same directory
+    run_model: Rscript run_model.R
+    exp_name: "r_streamlined_botorch_modular"
+
+generation_strategy:
+    steps:
+        - model: SOBOL
+          num_trials: 5
+        - model: BOTORCH_MODULAR
+          num_trials: -1  # No limitation on how many trials should be produced from this step
+          model_kwargs:
+              surrogate:
+                  botorch_model_class: SingleTaskGP  # BoTorch model class name
+
+                  covar_module_class: RBFKernel  # GPyTorch kernel class name
+                  mll_class: LeaveOneOutPseudoLikelihood
+              botorch_acqf_class: qUpperConfidenceBound  # BoTorch acquisition function class name
+              acquisition_options:
+                  beta: 0.5


### PR DESCRIPTION
Now users can customize their GP (kernel, MLL, GP class) as well as the acq func in the config without writing any code. Giving users a lot more control and power from any language with little setup